### PR TITLE
Fix incorrect PS/2 parsing

### DIFF
--- a/ps2.h
+++ b/ps2.h
@@ -414,7 +414,7 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
           return 95;
         case 0x5a:  // KP enter
           return 108;
-        case 0x12:  // KP PrtScr
+        case 0x7c:  // KP PrtScr
           return 124;
         case 0x15:  // Pause/Break
           return 126;


### PR DESCRIPTION
When I was testing the new SMC and Kernal code I noticed that some keys would result in two key codes being received by the Kernal. This was the case for amongst other the arrow keys.

This happened due to incorrect PS/2 key code parsing in the SMC code.

Some of the extended PS/2 codes are affected by the state of the Shift key and/or the Num Lock key as described on page 32 in this manual: http://mcamafia.de/pdf/ibm_hitrc11.pdf

We can take IBM key number 75 (Insert) as an example. The PS/2 key code (make / break) is normally E0 70 / E0 F0 70. If But if Left Shift is pressed it becomes E0 F0 12 E0 70 / E0 F0 70 E0 12. If Right Shift is pressed it becomes E0 F0 59 / E0 F0 70 E0 59. And if Num Lock is active it becomes E0 12 E0 70 / E0 F0 70 E0 F0 12.

Basically, it's a mess :-)

To send correct key codes to the Kernal we need to filter out all occurrences of E0 12, E0 F0 12, E0 59 and E0 F0 59 which has no meaning to us.