### PR TITLE
Fix bootloader start address

### DIFF
--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -4,7 +4,7 @@
 //     Michael Steil
 //     Joe Burks
 
-#define COMMUNITYX16_PINS
+//#define COMMUNITYX16_PINS
 #define ENABLE_NMI_BUT
 //#define KBDBUF_FULL_DBG
 


### PR DESCRIPTION
This fixes the bug in the present firmware that starts the bootloader.

The bootloader entry point address should be specified in words, not bytes as it is currently.