### PR TITLE
Github Action to publish a firmware+bootloader file

### DIFF
--- a/.doc/readme-community
+++ b/.doc/readme-community
@@ -37,3 +37,14 @@ IMPORTANT INFORMATION - PLEASE READ BEFORE INSTALLING
     following tool:
 
     https://github.com/FlightControl-User/x16-flash
+
+
+4.  The firmware_with_bootloader.hex file
+
+    This file contains the firmware and a bootloader
+    that makes it possible to update the SMC from the
+    X16.
+
+    The bootloader source code is available here:
+
+    https://github.com/stefan-b-jakobsson/x16-smc-bootloader

--- a/.doc/readme-default
+++ b/.doc/readme-default
@@ -33,3 +33,14 @@ IMPORTANT INFORMATION - PLEASE READ BEFORE INSTALLING
     following tool:
 
     https://github.com/FlightControl-User/x16-flash
+
+
+4.  The firmware_with_bootloader.hex file
+
+    This file contains the firmware and a bootloader
+    that makes it possible to update the SMC from the
+    X16.
+
+    The bootloader source code is available here:
+
+    https://github.com/stefan-b-jakobsson/x16-smc-bootloader

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,14 +32,23 @@ jobs:
         run: |
           mv .doc/readme-default .build/default/readme
           mv .doc/readme-community .build/community/readme
+
+      - name: Fetch bootloader
+        run: wget -O .build/bootloader.hex https://github.com/stefan-b-jakobsson/x16-smc-bootloader/releases/download/2/bootloader.hex 
       
+      - name: Create firmware_with_bootloader files
+        run: |
+          ./merge_bootloader.sh .build/default/x16-smc.ino.hex .build/bootloader.hex .build/default/firmware_with_bootloader.hex
+          ./merge_bootloader.sh .build/community/x16-smc.ino.hex .build/bootloader.hex .build/community/firmware_with_bootloader.hex
+
       - name: Archive default firmware
         uses: actions/upload-artifact@v3
         with:
           name: SMC default firmware
           path: |
-            .build/default/x16-smc.ino.hex
+            .build/default/firmware_with_bootloader.hex
             .build/default/x16-smc.ino.elf
+            .build/default/x16-smc.ino.hex
             .build/default/SMC*.BIN
             .build/default/readme
 
@@ -48,8 +57,9 @@ jobs:
         with:
           name: SMC CommunityX16 firmware
           path: |
-            .build/community/x16-smc.ino.hex
+            .build/community/firmware_with_bootloader.hex
             .build/community/x16-smc.ino.elf
+            .build/community/x16-smc.ino.hex
             .build/community/SMC*.BIN
             .build/community/readme
             

--- a/merge_bootloader.sh
+++ b/merge_bootloader.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ $# -ne 3 ] ; then
+    echo "Usage: merge_bootloader.sh path1 path2 path3"
+    echo "  path1: Path to firmware file in Intel HEX format"
+    echo "  path2: Path to bootloader file in Intel HEX format"
+    echo "  path3: Output file path"
+    exit 1
+else
+    grep -v ":00000001FF" $1 > .build/tmp.hex
+    cat .build/tmp.hex $2 > $3
+    rm .build/tmp.hex
+fi


### PR DESCRIPTION
This changes the Github Action build to fetch X16-SMC bootloader version 2 from https://github.com/stefan-b-jakobsson/x16-smc-bootloader.

The Action job makes one firmware_with_bootloader.hex file for each of the two supported platforms.

This file can be used for initial programming of the SMC with an external programmer. The bootloader makes it possible to do future updates from the X16 with no external programmer.

Please note that I've only tested the file for CommunityX16.