### PR TITLE
Revert to using https for azduino.com

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -1650,7 +1650,7 @@
               "name": "AzduinoUSB (t84, t841, t861, t1634)"
             },
             {
-              "name": "If Win USB drivers not already installed, run the post_install.bat manually or DL from http://azduino.com/bin/micronucleus"
+              "name": "If Win USB drivers not already installed, run the post_install.bat manually or DL from https://azduino.com/bin/micronucleus"
             }
           ],
           "toolsDependencies": [
@@ -1688,7 +1688,7 @@
               "name": "<br/><b>USB (Micronucleus) Support:</b> DigiSpark (t85), Digispark Pro (t167), MH-ET (t88), Wattuino/Nanite/etc (t841), CaliforniaSTEAM (t84)"
             },
             {
-              "name": "<br/><b>Windows users:</b> If USB drivers are not already installed, run the post_install.bat manually or DL from <a href=http://azduino.com/bin/micronucleus>http://azduino.com/bin/micronucleus</a>"
+              "name": "<br/><b>Windows users:</b> If USB drivers are not already installed, run the post_install.bat manually or DL from <a href=https://azduino.com/bin/micronucleus>https://azduino.com/bin/micronucleus</a>"
             }
           ],
           "toolsDependencies": [
@@ -1720,49 +1720,49 @@
               "checksum": "SHA-256:db8f92750d1c94669ba5d8b46e72d27d28ec927a19344cf42b7ae7bd1b5c30c9",
               "host": "x86_64-mingw32",
               "archiveFileName": "micronucleus-cli-2.5-azd1b-x86_64-mingw32.zip",
-              "url": "http://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1b-x86_64-mingw32.zip"
+              "url": "https://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1b-x86_64-mingw32.zip"
             },
             {
               "size": "1159717",
               "checksum": "SHA-256:5e795fb90598ea7a0e917965fc9bc6d536c405df50d2735f12b2fb8710bcec54",
               "host": "i686-mingw32",
               "archiveFileName": "micronucleus-cli-2.5-azd1b-i686-mingw32.zip",
-              "url": "http://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1b-i686-mingw32.zip"
+              "url": "https://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1b-i686-mingw32.zip"
             },
             {
               "size": "325836",
               "checksum": "SHA-256:c557d5769125f94b82ec2c30b1b68c9fb8a140e06b141aafb794907022f0bf56",
               "host": "aarch64-linux-gnu",
               "archiveFileName": "micronucleus-cli-2.5-azd1-aarch64-linux-gnu.tar.bz2",
-              "url": "http://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-aarch64-linux-gnu.tar.bz2"
+              "url": "https://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-aarch64-linux-gnu.tar.bz2"
             },
             {
               "size": "276745",
               "checksum": "SHA-256:cedf56ab3f2fdaa2ad2e55de26d73b41aa03c3ac9698ab3b719ef86d76487084",
               "host": "arm-linux-gnueabihf",
               "archiveFileName": "micronucleus-cli-2.5-azd1-arm-linux-gnueabihf.tar.bz2",
-              "url": "http://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-arm-linux-gnueabihf.tar.bz2"
+              "url": "https://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-arm-linux-gnueabihf.tar.bz2"
             },
             {
               "size": "372733",
               "checksum": "SHA-256:daea74a05671b14f619763dc21168103c9837c56ba84aa88c329979a1eac8bd7",
               "host": "i686-linux-gnu",
               "archiveFileName": "micronucleus-cli-2.5-azd1-i686-linux-gnu.tar.bz2",
-              "url": "http://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-i686-linux-gnu.tar.bz2"
+              "url": "https://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-i686-linux-gnu.tar.bz2"
             },
             {
               "size": "51607",
               "checksum": "SHA-256:cf0d268409ba8a5121225aceb5d8a562915b85bc96c270db5fb776a983355d51",
               "host": "x86_64-apple-darwin",
               "archiveFileName": "micronucleus-cli-2.5-azd1-x86_64-apple-darwin.tar.bz2",
-              "url": "http://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-x86_64-apple-darwin.tar.bz2"
+              "url": "https://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-x86_64-apple-darwin.tar.bz2"
             },
             {
               "size": "431381",
               "checksum": "SHA-256:1a9efa50e23fec004bf169579978882db6079b76c52da9188d149d270ded432c",
               "host": "x86_64-linux-gnu",
               "archiveFileName": "micronucleus-cli-2.5-azd1-x86_64-linux-gnu.tar.bz2",
-              "url": "http://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-x86_64-linux-gnu.tar.bz2"
+              "url": "https://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-x86_64-linux-gnu.tar.bz2"
             }
           ]
         },
@@ -1775,49 +1775,49 @@
               "checksum": "SHA-256:21b8a314b65b5143f1fcf865ec17a256d42894e6e95140b80146b60a779d4585",
               "host": "x86_64-mingw32",
               "archiveFileName": "micronucleus-cli-2.5-azd1-x86_64-mingw32.tar.bz2",
-              "url": "http://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-x86_64-mingw32.tar.bz2"
+              "url": "https://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-x86_64-mingw32.tar.bz2"
             },
             {
               "size": "1039040",
               "checksum": "SHA-256:69b7703c12dd0ead6547fd859bbf1a7450aa89d693fa93fc69f7e688cb69a9a6",
               "host": "i686-mingw32",
               "archiveFileName": "micronucleus-cli-2.5-azd1-i686-mingw32.tar.bz2",
-              "url": "http://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-i686-mingw32.tar.bz2"
+              "url": "https://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-i686-mingw32.tar.bz2"
             },
             {
               "size": "325836",
               "checksum": "SHA-256:c557d5769125f94b82ec2c30b1b68c9fb8a140e06b141aafb794907022f0bf56",
               "host": "aarch64-linux-gnu",
               "archiveFileName": "micronucleus-cli-2.5-azd1-aarch64-linux-gnu.tar.bz2",
-              "url": "http://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-aarch64-linux-gnu.tar.bz2"
+              "url": "https://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-aarch64-linux-gnu.tar.bz2"
             },
             {
               "size": "276745",
               "checksum": "SHA-256:cedf56ab3f2fdaa2ad2e55de26d73b41aa03c3ac9698ab3b719ef86d76487084",
               "host": "arm-linux-gnueabihf",
               "archiveFileName": "micronucleus-cli-2.5-azd1-arm-linux-gnueabihf.tar.bz2",
-              "url": "http://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-arm-linux-gnueabihf.tar.bz2"
+              "url": "https://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-arm-linux-gnueabihf.tar.bz2"
             },
             {
               "size": "372733",
               "checksum": "SHA-256:daea74a05671b14f619763dc21168103c9837c56ba84aa88c329979a1eac8bd7",
               "host": "i686-linux-gnu",
               "archiveFileName": "micronucleus-cli-2.5-azd1-i686-linux-gnu.tar.bz2",
-              "url": "http://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-i686-linux-gnu.tar.bz2"
+              "url": "https://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-i686-linux-gnu.tar.bz2"
             },
             {
               "size": "51607",
               "checksum": "SHA-256:cf0d268409ba8a5121225aceb5d8a562915b85bc96c270db5fb776a983355d51",
               "host": "x86_64-apple-darwin",
               "archiveFileName": "micronucleus-cli-2.5-azd1-x86_64-apple-darwin.tar.bz2",
-              "url": "http://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-x86_64-apple-darwin.tar.bz2"
+              "url": "https://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-x86_64-apple-darwin.tar.bz2"
             },
             {
               "size": "431381",
               "checksum": "SHA-256:1a9efa50e23fec004bf169579978882db6079b76c52da9188d149d270ded432c",
               "host": "x86_64-linux-gnu",
               "archiveFileName": "micronucleus-cli-2.5-azd1-x86_64-linux-gnu.tar.bz2",
-              "url": "http://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-x86_64-linux-gnu.tar.bz2"
+              "url": "https://azduino.com/bin/micronucleus/micronucleus-cli-2.5-azd1-x86_64-linux-gnu.tar.bz2"
             }
           ]
         },
@@ -1835,7 +1835,7 @@
             {
               "host": "i686-mingw32",
               "archiveFileName": "micronucleus-2.0a4-win.zip",
-              "url": "http://azduino.com/bin/micronucleus-2.0a4-win.zip",
+              "url": "https://azduino.com/bin/micronucleus-2.0a4-win.zip",
               "checksum": "SHA-256:BA9D4A327FCDEE92B72DDD353EF547FB071110E9EB7BE73F83A685CB76D3F939",
               "size": "1711851"
             },


### PR DESCRIPTION
azduino.com seems to have renewed its server certificate, and we should revert to using https.

Closes issue #26.