### PR TITLE
Change functionality of activity LED to only on/off

### DIFF
--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -249,7 +249,7 @@ void I2C_Process() {
   }
   // ["Byte 4 - Power LED Level" removed]
   if (I2C_Data[0] == 5) {                     // 1st Byte : Byte 5 - Activity LED Level
-    analogWrite(ACT_LED, I2C_Data[1]);      // 2nd Byte : Set Value directly
+    digitalWrite(I2C_Data[1]==0?LOW:HIGH);    // 2nd Byte : Set the activity LED
   }
 
   if (I2C_Data[0] == 7) {                     // 1st Byte : Byte 7 - Keyboard: read next keycode

--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -249,7 +249,7 @@ void I2C_Process() {
   }
   // ["Byte 4 - Power LED Level" removed]
   if (I2C_Data[0] == 5) {                     // 1st Byte : Byte 5 - Activity LED Level
-    digitalWrite(I2C_Data[1]==0?LOW:HIGH);    // 2nd Byte : Set the activity LED
+    digitalWrite(ACT_LED, I2C_Data[1]==0?LOW:HIGH);    // 2nd Byte : Set the activity LED
   }
 
   if (I2C_Data[0] == 7) {                     // 1st Byte : Byte 7 - Keyboard: read next keycode


### PR DESCRIPTION
The activity LED is not actually connected to a pin on the SMC that is able to do PWM output.
Code will now take any value other than 0 and turn the activity led on. 0 will turn activity led off.