### PR TITLE
Flash manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The SMC is responsible for
 | 0x43      | Master read       | 1 byte            | Get PS/2 Data Fast            |
 | 0x8e      | Master write      | 1 byte            | Get Bootloader Version        |
 | 0x8f      | Master write      | 0x31              | Start bootloader              |
+| 0x90      | Master write      | 1 byte            | Set flash page (0-127)        |
+| 0x91      | Master read       | 1 byte            | Read flash                    |
 
 
 ## Power, Reset and Non-Maskable Interrupt (0x01, 0x02, 0x03)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The SMC is responsible for
 | 0x90      | Master write      | 1 byte            | Set flash page (0-127)        |
 | 0x91      | Master read       | 1 byte            | Read flash                    |
 | 0x92      | Master write      | 1 byte            | Write flash                   |
+| 0x93      | Master read       | 1 byte            | Get flash write mode          |
+| 0x93      | Master write      | 1 byte            | Request flash write mode      |
 
 
 ## Power, Reset and Non-Maskable Interrupt (0x01, 0x02, 0x03)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The SMC is responsible for
 | 0x8f      | Master write      | 0x31              | Start bootloader              |
 | 0x90      | Master write      | 1 byte            | Set flash page (0-127)        |
 | 0x91      | Master read       | 1 byte            | Read flash                    |
+| 0x92      | Master write      | 1 byte            | Write flash                   |
 
 
 ## Power, Reset and Non-Maskable Interrupt (0x01, 0x02, 0x03)


### PR DESCRIPTION
This PR adds functionality to read flash, and manipulate bootloader area of flash.

Ordinary users will likely not need the feature of writing to bootloader area of flash every day. Maybe they will only need it once, ever, when they replace the bad bootloader 2 with a good bootloader 2 (or a newer bootloader).

However. There is a risk involved in supporting commands which can write to the bootloader flash, as bootloader can be unintentional (or even malicious) manipulated. Thus, I suggest to at least protect this feature by not enabling it by default, it requires a specially built version which includes this feature. This also frees up some space for other features. Additionally, we could also add some button protection for the feature, I am testing this in branch "make-programming-safer".

Let me know what you think:
- Should we require a special FW to use the flash manipulation features (to avoid unintentional use), or should we include this functionality in standard SMC firmware?
- If we only include the flash manipulation feature in a special SMC FW, should the feature be button-protected?
- Do you agree that we should limit flash manipulation functionality to bootloader area only? This will at least ensure that the flash manipulation functionality does not overwrite itself/the running program, reducing the chance of bricking the SMC