### PR TITLE
Add PS/2 clock hold during power on

### DIFF
--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -324,6 +324,8 @@ void PowerOffSeq() {
 
 void PowerOnSeq() {
   assertReset();
+  digitalWrite_opt(PS2_KBD_CLK, LOW);         // hold PS/2 clock during power-on procedure
+  pinMode_opt(PS2_KBD_CLK, OUTPUT);
   digitalWrite_opt(PWR_ON, LOW);              // turn on power supply
   unsigned long TimeDelta = 0;
   unsigned long StartTime = millis();         // get current time


### PR DESCRIPTION
This PR will hold the PS/2 clock low for about 2.5 s after system power on, to test if some Dell RT7D20 will start working.