### PR TITLE
Always use pullup with ps2 logic, except when PSU is off

### DIFF
--- a/optimized_gpio.h
+++ b/optimized_gpio.h
@@ -8,9 +8,14 @@
 extern "C" {
 #endif
 
+// Arduino-style interface
 extern inline void pinMode_opt(uint8_t pin, uint8_t mode) __attribute__((always_inline));
 extern inline void digitalWrite_opt(uint8_t pin, uint8_t val) __attribute__((always_inline));
 extern inline uint8_t digitalRead_opt(uint8_t pin) __attribute__((always_inline));
+
+// Convenience functions to choose between input+pullup and output+low, needed by e.g. PS2
+extern inline void gpio_inputWithPullup(uint8_t pin) __attribute__((always_inline));
+extern inline void gpio_driveLow(uint8_t pin) __attribute__((always_inline));
 
 #ifdef __cplusplus
 }

--- a/ps2.h
+++ b/ps2.h
@@ -4,6 +4,8 @@
 #include "optimized_gpio.h"
 #define SCANCODE_TIMEOUT_MS 50
 
+bool PWR_ON_active();
+
 enum PS2_CMD_STATUS : uint8_t {
   IDLE = 0,
   CMD_PENDING = 1,
@@ -44,8 +46,15 @@ class PS2Port
     };
 
     virtual void resetInput() {
-      gpio_inputWithPullup(datPin);
-      gpio_inputWithPullup(clkPin);
+      if (PWR_ON_active()) {
+        gpio_inputWithPullup(datPin);
+        gpio_inputWithPullup(clkPin);
+      } else {
+        // Prevent powering the keyboard via the pull-ups when system is off
+        // Call reset() after changing PWR_ON
+        pinMode_opt(datPin, INPUT);
+        pinMode_opt(clkPin, INPUT);
+      }
       curCode = 0;
       parity = 0;
       rxBitCount = 0;

--- a/ps2.h
+++ b/ps2.h
@@ -44,8 +44,8 @@ class PS2Port
     };
 
     virtual void resetInput() {
-      pinMode_opt(datPin, INPUT);
-      pinMode_opt(clkPin, INPUT);
+      gpio_inputWithPullup(datPin);
+      gpio_inputWithPullup(clkPin);
       curCode = 0;
       parity = 0;
       rxBitCount = 0;
@@ -173,12 +173,10 @@ class PS2Port
         case 7:
           //Output data bits 0-7
           if (outputBuffer[0] & 1) {
-            pinMode_opt(datPin, INPUT);
-            digitalWrite_opt(datPin, HIGH);
+            gpio_inputWithPullup(datPin);
           }
           else {
-            digitalWrite_opt(datPin, LOW);
-            pinMode_opt(datPin, OUTPUT);
+            gpio_driveLow(datPin);
           }
 
           //Update parity
@@ -194,12 +192,10 @@ class PS2Port
         case 8:
           //Send odd parity bit
           if ((parity & 1) == 1) {
-            digitalWrite_opt(datPin, LOW);
-            pinMode_opt(datPin, OUTPUT);
+            gpio_driveLow(datPin);
           }
           else {
-            pinMode_opt(datPin, INPUT);
-            digitalWrite_opt(datPin, HIGH);
+            gpio_inputWithPullup(datPin);
           }
 
           //Prepare for stop bit
@@ -208,8 +204,7 @@ class PS2Port
 
         case 9:
           //Stop bit
-          pinMode_opt(datPin, INPUT);
-          digitalWrite_opt(datPin, HIGH);
+          gpio_inputWithPullup(datPin);
           rxBitCount++;
           break;
 
@@ -291,11 +286,8 @@ class PS2Port
 
       else if (timerCountdown == 3) {
         //Initiate request-to-send sequence
-        digitalWrite_opt(clkPin, LOW);
-        pinMode_opt(clkPin, OUTPUT);
-
-        digitalWrite_opt(datPin, LOW);
-        pinMode_opt(datPin, OUTPUT);
+        gpio_driveLow(clkPin);
+        gpio_driveLow(datPin);
 
         ps2ddr = 1;
         timerCountdown--;
@@ -303,7 +295,7 @@ class PS2Port
 
       else if (timerCountdown == 1) {
         //We are at end of the request-to-send clock hold time of minimum 100 us
-        pinMode_opt(clkPin, INPUT);
+        gpio_inputWithPullup(clkPin);
 
         timerCountdown = 0;
         rxBitCount = 0;

--- a/version.h
+++ b/version.h
@@ -1,3 +1,3 @@
 #define version_major 47
 #define version_minor 2
-#define version_patch 0
+#define version_patch 1


### PR DESCRIPTION
This PR adds two GPIO helper functions, to simplify toggling between input+pullup and output+driving low.

This is used in PS2 logic, to simplify the code there.

This also fixes a few places where the old logic would set input without pullup. This causes problems on some keyboards, as this causes that only the external 4.7k pullup resistor is used. Which is not fast enough for at least one Dell keyboard.

This change causes the mentioned Dell keyboard to work again, without needing additional pull-up resistors.