### PR TITLE
Mouse init procedure update

### DIFF
--- a/setup_mouse.cpp
+++ b/setup_mouse.cpp
@@ -180,7 +180,7 @@ void mouseTick() {
             break;
 
         case MOUSE_STATE_SET_SAMPLERATE:
-            Mouse.sendPS2Command(PS2_CMD_SET_SAMPLE_RATE, 40);
+            Mouse.sendPS2Command(PS2_CMD_SET_SAMPLE_RATE, 60);
             state = MOUSE_STATE_SET_SAMPLERATE_ACK;
             watchdog = WATCHDOG_ARM;
             break;

--- a/setup_mouse.cpp
+++ b/setup_mouse.cpp
@@ -73,6 +73,7 @@ static volatile uint8_t watchdogExpiryState = MOUSE_STATE_OFF;
 
 void mouseTick() {
     static uint8_t watchdog = WATCHDOG_DISABLE;
+    uint8_t mouse_id_prev;
     
     // Return to OFF state if system powered down
     if (!SYSTEM_POWERED && state != MOUSE_STATE_OFF) {
@@ -134,10 +135,12 @@ void mouseTick() {
             break;
 
         case MOUSE_STATE_INTELLI_2:
-            if (requestedmouse_id == 3) {
+            if (mouse_id == 0) {
+                // If mouse_id is 0, this is the 1st round of Intellimouse setup, go for ID=3
                 Mouse.sendPS2Command(PS2_CMD_SET_SAMPLE_RATE, 100);
             }
             else {
+                // If mouse_id is not 0, this is the 2nd round of Intellimouse setup, go for ID=4
                 Mouse.sendPS2Command(PS2_CMD_SET_SAMPLE_RATE, 200);
             }
             state = MOUSE_STATE_INTELLI_2_ACK;
@@ -158,27 +161,26 @@ void mouseTick() {
         
         case MOUSE_STATE_INTELLI_GET_ID:
             if (Mouse.available()) {
+                mouse_id_prev = mouse_id;
                 mouse_id = Mouse.next();
-                if (mouse_id == requestedmouse_id || (mouse_id == 0 && requestedmouse_id == 3)) {
-                    // Setup succeded, or accept downgrade from mouse ID 3 to mouse ID 0
+
+                if (mouse_id == 0 || mouse_id == requestedmouse_id || mouse_id_prev == 3) {
+                    // Intellimouse setup complete:
+                    // mouse_id == 0                 => Not an Intellimouse
+                    // mouse_id == requestedmouse_id => We got the requested ID, stop here
+                    // mouse_id_prev == 3            => This was the second round, unsuccessul config of ID=4, nohting more to do
                     state = MOUSE_STATE_SET_SAMPLERATE;
                 }
-                else if (mouse_id == 0 && requestedmouse_id == 4) {
-                    // Setup failed, try to downgrade to mouse ID 3
-                    requestedmouse_id = 3;
-                    state = MOUSE_STATE_RESET;
-                }
                 else {
-                    // Setup failed, try to downgrade to mouse ID 0
-                    requestedmouse_id = 0;
-                    state = MOUSE_STATE_RESET;
+                    // Run Intellimouse setup again to test ID=4
+                    state = MOUSE_STATE_INTELLI_1;
                 }
                 watchdog = WATCHDOG_DISABLE;
             }
             break;
 
         case MOUSE_STATE_SET_SAMPLERATE:
-            Mouse.sendPS2Command(PS2_CMD_SET_SAMPLE_RATE, 60);
+            Mouse.sendPS2Command(PS2_CMD_SET_SAMPLE_RATE, 40);
             state = MOUSE_STATE_SET_SAMPLERATE_ACK;
             watchdog = WATCHDOG_ARM;
             break;

--- a/setup_mouse.cpp
+++ b/setup_mouse.cpp
@@ -166,9 +166,9 @@ void mouseTick() {
 
                 if (mouse_id == 0 || mouse_id == requestedmouse_id || mouse_id_prev == 3) {
                     // Intellimouse setup complete:
-                    // mouse_id == 0                 => Not an Intellimouse
+                    // mouse_id == 0                 => Not an Intellimouse, stop here
                     // mouse_id == requestedmouse_id => We got the requested ID, stop here
-                    // mouse_id_prev == 3            => This was the second round, unsuccessul config of ID=4, nohting more to do
+                    // mouse_id_prev == 3            => This was the second round, unsuccessul config of ID=4, nothing more to do
                     state = MOUSE_STATE_SET_SAMPLERATE;
                 }
                 else {

--- a/version.h
+++ b/version.h
@@ -1,3 +1,3 @@
 #define version_major 47
 #define version_minor 2
-#define version_patch 2
+#define version_patch 3


### PR DESCRIPTION
Updating the mouse init procedure as discussed on Discord.

Currently the mouse init function first tries to config mouse ID 4 (Intellimouse with scroll wheel and extra buttons). If that fails, it then tries to config mouse ID 3 (Intellimouse with scroll wheel, no extra buttons).

For most mice this is OK, but at least some will falsely report to be ID 4 during the first above mentioned step, causing the mouse not to work properly. This concerns at least a MCSaite PS/2 wired mouse (https://www.amazon.com/MCSaite-Wired-PS2-Optical-Mouse/dp/B0B456JY5G).

According to this document, a PC would do the init the other way around, first trying to config ID 3 and then ID 4 (https://isdaman.com/alsos/hardware/mouse/ps2interface.htm).

The SMC firmware did it that way before 47.0. I think it's best to revert the init procedure to first try to config ID 3 and then ID 4. Even though the MCSaite mouse still falsely reports to be a 4, it still at least works.

Changing the setup routine could cause issues for other mice. We would need some testing before merging this.

So far it works with my mice:
- Perixx 201
- Old HP mouse

Reportedly it also works with:
- MCSaite mouse