### PR TITLE
Update to latest version of setup-arduino-cli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           python-version: '3.9'
       - name: Setup Arduino CLI
-        uses: arduino/setup-arduino-cli@v1
+        uses: arduino/setup-arduino-cli@v2
       - name: Install ATTinyCore platform
         run: |
           arduino-cli core update-index --additional-urls file://$PWD/package_drazzy.com_index.json


### PR DESCRIPTION
This updates arduino/setup-arduino-cli from v1 to the newly released v2.

Currently, automatic builds in Github Actions produce a warning about NodeJS 1.6 being used. Github plans to drop support for that version of NodeJS during at any time now (originally said to be Spring of 2024).

After switching to arduino/setup-arduino-cli@v2, the warning should disappear.

It's such a minor change that doesn't affect the resulting firmware, so I haven't bumped the SMC firmware version.