### PR TITLE
Add bootloader project as subfolder

### DIFF
--- a/bootloader/Makefile
+++ b/bootloader/Makefile
@@ -1,0 +1,15 @@
+BUILD_DIR=build
+SRC_FILES=$(wildcard *.asm *.inc)
+
+# Bootloader
+$(BUILD_DIR)/bootloader.hex: $(SRC_FILES)
+	@mkdir -p $(BUILD_DIR)
+	avra -o $@ -W NoRegDef main.asm
+	rm -f main.eep.hex	
+	rm -f main.obj
+	python scripts/merge_firmware_and_bootloader.py
+	python scripts/convert_hex2bin.py
+ 
+# Clean
+clean:
+	rm -f $(BUILD_DIR)/*

--- a/bootloader/README.md
+++ b/bootloader/README.md
@@ -1,0 +1,206 @@
+# Purpose
+
+This is a custom bootloader for the Commander X16 ATTiny861 based System Management Controller (SMC).
+
+The purpose of the bootloader is to make it possible to update the SMC firmware from the Commander X16 without using an external programmer.
+
+Firmware data is transmitted from the computer to the SMC over I2C.
+
+# How it works
+
+## SMC memory map
+
+| Byte address  | Size        | Description                |
+|-------------- |-------------| ---------------------------|
+| 0x0000-0x1DFF | 7,680 bytes | Firmware area              |
+| 0x0000        | 2 bytes     | Reset vector               |
+| 0x0012        | 2 bytes     | EE_RDY vector              |
+| 0x1E00-0x1FFF | 512 bytes   | Bootloader area            |
+| 0x1E00        | 2 bytes     | Bootloader main vector     |
+| 0x1E02        | 2 bytes     | Start update vector        |
+| 0x1FFE        | 2 bytes     | Bootloader version         |    
+
+
+## SMC reset procedure
+
+On SMC reset the reset vector at address 0x0000 is always executed.
+This happens both when mains power is connected to the computer
+and when the SMC reset pin #10 is grounded.
+
+When the bootloader is installed, the reset vector is 
+remapped and always jumps to the bootloader main vector (0x1E00).
+
+The bootloader main function checks if the Reset button is being pressed. 
+If the button is pressed, the computer is powered on and the 
+bootloader's firmware update process is started.
+
+If the Reset button was not pressed, the bootloader jumps to
+the vector stored in EE_RDY (0x0012). The firmware's original
+reset vector is always moved to this address when updating
+the firmware.
+
+
+## Firmware update procedure
+
+The update procedure can be started by holding down the Reset 
+button as described [above](#smc-reset-procedure).
+
+The procedure can also be started by requesting the
+firmware to call the start update vector (0x1e02). This is 
+done through the I2C command 0x8F (Start bootloader).
+
+While the update procedure is active, firmware data 
+is transmitted from the CPU to the SMC over I2C as
+follows:
+
+- 8 bytes plus 1 checksum byte are transmitted
+using the 0x80 I2C command (Transmit).
+
+- The transmitted bytes are committed with
+the 0x81 I2C command (Commit).
+
+- Transmitting and committing data is
+repeated for the rest of the firmware.
+
+- The flash memory is updated in pages of 64 bytes (pages). On every
+8th commit, firmware data will actually be written to flash
+memory.
+
+- Just before writing the first flash memory page, all of
+the firmware flash area is erased, starting from the last page.
+
+- Finally, the update program is expected to call
+the 0x82 I2C command (Reboot) to reset the SMC and power
+off the system. This will also write
+any remaining data to flash memory.
+
+If the update procedure was started by holding down
+the Reset button, the system has no keyboard or mouse
+connection. SMCUPDATE-x.x.x.PRG needs to stored as AUTOBOOT.X16
+on the SD card so that it is automatically loaded and run.
+
+
+# Building the project
+
+The firmware hex file (x16-smc.ino.hex) is expected to be found at x16-smc/build. You need
+to build or download the firmware and store it there. The firmware is
+typically built with the Arduino IDE.
+
+Type ```make``` to build the bootloader.
+
+Build dependencies:
+
+- AVRA assembler https://github.com/Ro5bert/avra
+
+- Python 3
+
+- Python intelhex module, install with pip intelhex
+
+
+# Fuse settings
+
+The bootloader and the SMC firmware depend on several ATtiny fuse settings as set out below.
+
+The recommended low fuse value is 0xF1. This will run the SMC at 16 MHz.
+
+The recommended high fuse value is 0xD4. This enables Brown-out Detection at 4.3V, which is necessary to prevent flash memory corruption when self-programming is enabled. Serial Programming should be enabled (bit 5) and external reset disable should not be selected (bit 7). These settings are necessary for programming the SMC with an external programmer.
+
+Finally, the extended fuse value must be 0xFE to enable self-programming of the flash memory. The bootloader cannot work without this setting.
+
+
+# Initial programming of the SMC with avrdude
+
+The initial programming of the SMC must be done with an
+external programmer.
+
+The command line utility avrdude is the recommended tool together
+with a programmer that is compatible with avrdude.
+
+Example 1. Set fuses
+```
+avrdude -cstk500v1 -Cavrdude.conf -pattiny861 -P<your port> -b19200 -Ulfuse:w:0xF1:m -Uhfuse:w:0xD4:m -Uefuse:w:0xFE:m
+```
+
+Example 2. Write to flash
+```
+avrdude -cstk500v1 -Cavrdude.conf -pattiny861 -P<your port> -b19200 -Uflash:w:build/firmware_with_bootloader.hex:i
+```
+
+The -c option selects programmer-id; stk500v1 is for using Arduino UNO as an In-System Programmer. If you have another ISP programmer, you may need to change this value accordingly.
+
+The -p option selects the target device, always attiny861.
+
+The -P option selects port name on the host computer.
+
+The -b option sets transmission baudrate; 19200 is a good value.
+
+The -U option performs a memory operation. "-U flash:w:filename:i" writes to flash memory. "-U lfuse:w:0xF1:m" writes the low fuse value.
+
+Please note that some fuse settings may cause the ATtiny861 not to respond. Resetting might require equipment for high voltage programming. Be careful if you choose not to use the recommended values.
+
+The Arduino IDE also uses avrdude in the background. If you have installed the IDE can use it to program the SMC, you may enable verbose output and see what parameters are used by the IDE when it starts avrdude.
+
+
+# I2C API
+
+## Command 0x80 = Transmit (master write)
+
+The transmit command is used to send a data packet to the bootloader.
+
+A packet consists of 8 bytes to be written to flash and 1 checksum byte.
+
+The checksum is the two's complement of the least significant byte of the sum of the previous bytes in the packet. The least significant byte of the sum of all 9 bytes in a packet will consequently always be 0.
+
+## Command 0x81 = Commit (master read)
+
+After a data packet of 9 bytes has been transmitted it must be committed with this command. 
+
+The first commit will target flash memory address 0x0000. The target address is moved forward 8 bytes on each successful commit.
+
+The command returns 1 byte. The possible return values are:
+
+Value | Description
+------|-------------
+1     | OK
+2     | Error, packet size not 9
+3     | Checksum error
+4     | Reserved
+5     | Error, overwriting bootloader section
+
+The firmware flash memory are will be erased on the 8th successful commit, just before writing the first 64 bytes to flash memory.
+
+## Command 0x82 = Reboot (master write)
+
+The reboot command must always be called after the last packet
+has been committed. If not, the SMC may be left in an inoperable
+state.
+
+The command first writes any buffered data to flash.
+
+The bootloader then resets the SMC. The SMC reset shuts down the computer. It
+can be restarted by pressing the power button. It is not necessary to power cycle the system
+after an update.
+
+## Command 0x83 = Get bootloader version (master read)
+
+This command returns the bootloader version.
+
+Available since bootloader v3.
+
+## Command 0x84 = Rewind target address (master write)
+
+Rewinds the target address to 0.
+
+Available since bootloader v3.
+
+## Command 0x85 = Read flash memory
+
+Reads one byte of flash memory at the current target address.
+
+The target address is post-incremented one byte.
+
+This function is primarily intended to be used for verifying the
+content of the flash memory after an update.
+
+Available since bootloader v3.
+

--- a/bootloader/command.inc
+++ b/bootloader/command.inc
@@ -1,0 +1,192 @@
+; Copyright 2023-2024 Stefan Jakobsson
+; 
+; Redistribution and use in source and binary forms, with or without modification, 
+; are permitted provided that the following conditions are met:
+;
+; 1. Redistributions of source code must retain the above copyright notice, this 
+;    list of conditions and the following disclaimer.
+;
+; 2. Redistributions in binary form must reproduce the above copyright notice, 
+;    this list of conditions and the following disclaimer in the documentation 
+;    and/or other materials provided with the distribution.
+;
+;    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
+;    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+;    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS 
+;    BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+;    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+;    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+;    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+;    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+;    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+;    THE POSSIBILITY OF SUCH DAMAGE.
+
+
+;******************************************************************************
+; Function...: CMD_RECEIVE_PACKET
+; Description: Receives a packet byte and stores it into an SRAM buffer. This
+;              function keeps track of and updates the pointer to the
+;              head of the RAM buffer, the current packet size and the
+;              checksum of the current packet.
+; In.........: r16 byte value
+; Out........: Nothing
+.macro CMD_RECEIVE_PACKET
+    ; Check packet size
+    cpi packet_size,10
+    brsh cmd_receive_byte_exit                          ; 11th byte or more - packet overflow, an error state
+    cpi packet_size,9
+    breq cmd_receive_byte3                              ; 10th byte - packet overflow, an error state
+    cpi packet_size,8                                                                                
+    breq cmd_receive_byte2                              ; 9th byte is the checksum
+                                                            
+    ; Store byte in buffer
+    st Y+, r16                                          ; Store byte in buffer and increment Y = packet_addressH:packet_addressL
+
+    ; Update checksum
+cmd_receive_byte2:
+    add checksum, r16                                   ; Add without carry
+
+    ; Increment packet size
+cmd_receive_byte3:
+    inc packet_size
+
+cmd_receive_byte_exit:
+.endm
+ 
+;******************************************************************************
+; Function...: CMD_COMMIT
+; Description: Confirm and request that the current packet is written to
+;              flash memory
+; In.........: Nothing
+; Out........: r17 Response value:
+;                  0x01 = OK, buffer written to flash memory
+;                  0x02 = Invalid packet size, not equal to 9
+;                  0x03 = Checksum error
+;                  0x04 = Reserved
+;                  0x05 = Target address overflows into bootloader section (0x1E00..)
+.macro CMD_COMMIT
+    ; Verify packet
+    ldi r17, 2
+    cpi packet_size, 9                           ; Packet size == 9?
+    brne cmd_commit_err
+    
+    ldi r17, 3
+    cpi checksum, 0                              ; Checksum == 0?
+    brne cmd_commit_err
+    
+    ldi r17, 5
+    cpi target_addrH,0x1e                        ; Target address >= 0x1E00 (in bootloader area)?
+    brsh cmd_commit_err
+
+    ; Do we have a full page?
+    inc packet_count
+    cpi packet_count, 8
+    brne cmd_commit_ok
+
+cmd_commit_write:
+    ; Erase if first page
+    mov r16, chip_erased
+    cpi r16, 0
+    brne cmd_commit_write2
+    rcall flash_erase
+    inc chip_erased
+
+    ; Move reset vector to EE_RDY
+    lds r26, flash_buf
+    lds r27, flash_buf+1
+    sbiw r27:r26, ERDYaddr
+    andi r27, 0b11001111
+    ori r27, 0b11000000
+    sts flash_buf+(ERDYaddr*2), r26
+    sts flash_buf+(ERDYaddr*2)+1, r27
+
+    ; Replace reset vector with rjmp 0xf00 (= 0xceff)
+    ldi r16, 0xff
+    ldi r17, 0xce
+    sts flash_buf, r16
+    sts flash_buf+1, r17
+
+cmd_commit_write2:
+    ; Write buffer to flash mem
+    rcall flash_write
+
+    ; Update target addr
+    adiw target_addrH:target_addrL, 32
+    adiw target_addrH:target_addrL, 32
+ 
+    ; Clear buffer
+    rcall flash_clear_buf
+
+    ; Reset packet count
+    clr packet_count
+
+cmd_commit_ok:
+    ; Load return value
+    ldi r17,1
+    
+    ; Move buffer tail to head
+    movw packet_tailH:packet_tailL, packet_headH:packet_headL
+    rjmp cmd_commit_exit
+
+cmd_commit_err:
+    ; Rewind buffer head to tail
+    movw packet_headH:packet_headL, packet_tailH:packet_tailL
+
+cmd_commit_exit:
+    movw checksum:packet_size, zeroH:zeroL
+
+.endm
+
+;******************************************************************************
+; Function...: CMD_REBOOT
+; Description: Writes remainging data in the buffer to flash and resets the SMC
+; In.........: Nothing
+; Out........: Nothing
+.macro CMD_REBOOT
+    ; Write possible data in current buffer to flash
+    cpi packet_count, 0
+    breq cmd_reboot2
+    rcall flash_write
+
+cmd_reboot2:
+    ; Set watchdog reset after 1 second
+    ldi r16,(1<<WDE) | (0<<WDIE) | (0<<WDP3) | (1<<WDP2) | (1<<WDP1) | (0<<WDP0)
+    out WDTCR,r16
+
+cmd_reboot_3:
+    ; Wait here until reset
+    rjmp cmd_reboot_3
+.endm
+
+;******************************************************************************
+; Function...: CMD_GET_VERSION
+; Description: Returns bootloader version stored at 0x1fff
+; In.........: Nothing
+; Out........: r17 Version number
+.macro CMD_GET_VERSION
+    movw r19:r18, ZH:ZL
+    ldi ZL, 0xff
+    ldi ZH, 0x1f
+    lpm r17, Z
+    movw ZH:ZL, r19:r18
+.endm
+
+;******************************************************************************
+; Function...: CMD_REWIND_TARGET_ADDR
+; Description: Sets target address to 0
+; In.........: Nothing
+; Out........: Nothing
+.macro CMD_REWIND_TARGET_ADDR
+    movw ZH:ZL, zeroH:zeroL
+.endm
+
+;******************************************************************************
+; Function...: CMD_READ_FLASH
+; Description: Reads one byte from flash memory and advances target
+;              address pointer
+; In.........: Nothing
+; Out........: r17 byte value
+.macro CMD_READ_FLASH
+    lpm r17, Z+
+.endm

--- a/bootloader/flash.asm
+++ b/bootloader/flash.asm
@@ -1,0 +1,128 @@
+; Copyright 2023-2024 Stefan Jakobsson
+; 
+; Redistribution and use in source and binary forms, with or without modification, 
+; are permitted provided that the following conditions are met:
+;
+; 1. Redistributions of source code must retain the above copyright notice, this 
+;    list of conditions and the following disclaimer.
+;
+; 2. Redistributions in binary form must reproduce the above copyright notice, 
+;    this list of conditions and the following disclaimer in the documentation 
+;    and/or other materials provided with the distribution.
+;
+;    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
+;    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+;    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS 
+;    BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+;    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+;    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+;    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+;    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+;    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+;    THE POSSIBILITY OF SUCH DAMAGE.
+
+.equ PAGE_SIZE      = 0x40      ; In bytes
+.equ FIRMWARE_SIZE  = 0x1e00    ; In bytes
+
+;******************************************************************************
+; Data segment
+;******************************************************************************
+.dseg
+
+flash_buf:          .byte PAGE_SIZE
+
+;******************************************************************************
+; Program segment
+;******************************************************************************
+.cseg
+
+;******************************************************************************
+; Function...: flash_erase
+; Description: Erases firmware (byte address 0x0000-0x1dff),
+;              starting from the last page; target address is guaranteed to
+;              be 0x0000 when returning from this function
+; In.........: Nothing
+; Out........: target_addr = 0x0000
+flash_erase:
+    ldi target_addrL, low(FIRMWARE_SIZE - PAGE_SIZE)
+    ldi target_addrH, high(FIRMWARE_SIZE - PAGE_SIZE)
+flash_erase_loop:
+    ldi r17, (1<<PGERS) + (1<<SPMEN)
+    rcall flash_spm
+    subi ZL, 64
+    sbci ZH, 0
+    brcc flash_erase_loop
+
+    movw target_addrH:target_addrL, zeroH:zeroL
+
+    ret
+
+;******************************************************************************
+; Function...: flash_write
+; Description: Writes one page (64 bytes) to flash memory
+; In.........: ZH:ZL Flash memory target address (in bytes, not words)
+; Out........: Nothing
+flash_write:
+    ldi YL,low(flash_buf)
+    ldi YH,high(flash_buf)
+    ldi r16, PAGE_SIZE              ; Init counter
+    
+flash_write_loop:
+    ; Copy data from RAM buffer pointed to by Y into SPM temp buffer
+    ld r0, Y+                       ; Copy one word from buffer into r0:r1
+    ld r1, Y+
+    ldi r17, (1<<SPMEN)
+    rcall flash_spm                 ; Perform copy
+  
+    adiw ZH:ZL, 2                   ; Z = Z + 2
+    subi r16, 2                     ; counter = counter - 2
+    brne flash_write_loop           ; Check if we're done
+
+    ; Write page
+    sbiw ZH:ZL, PAGE_SIZE/2         ; Restore flash memory address to its start value
+    sbiw ZH:ZL, PAGE_SIZE/2
+
+    ldi r17, (1<<PGWRT) + (1<<SPMEN)
+    
+    ; Fallthrough to flash_spm
+
+;******************************************************************************
+; Function...: flash_spm
+; Description: Performs Store Program Meomory operation
+; In.........: r17 Value to be written to SPMCSR before operation, selecting
+;                  SPM command
+; Out........: Nothing
+flash_spm:
+    ; Wait for SPM not busy (SPMEN=0)
+    in r19, SPMCSR
+    sbrc r19, SPMEN
+    rjmp flash_spm
+
+    ; Perform SPM
+    out SPMCSR, r17
+    spm
+
+flash_spm2:
+    ; Wait for SPM to finish
+    in r19, SPMCSR
+    and r19, r17
+    brne flash_spm2
+
+    ret
+
+;******************************************************************************
+; Function...: flash_clear_buf
+; Description: Fills buffer with 0xff
+; In.........: Nothing
+; Out........: YH:YL = flash_buf
+flash_clear_buf:
+    ldi YL, low(flash_buf + PAGE_SIZE)
+    ldi YH, high(flash_buf + PAGE_SIZE)
+    ldi r16, PAGE_SIZE
+    ldi r17, 0xff
+flash_clear_buf_loop:
+    st -Y, r17
+    dec r16 
+    brne flash_clear_buf_loop
+    ret

--- a/bootloader/i2c.asm
+++ b/bootloader/i2c.asm
@@ -1,0 +1,259 @@
+; Copyright 2023-2024 Stefan Jakobsson
+; 
+; Redistribution and use in source and binary forms, with or without modification, 
+; are permitted provided that the following conditions are met:
+;
+; 1. Redistributions of source code must retain the above copyright notice, this 
+;    list of conditions and the following disclaimer.
+;
+; 2. Redistributions in binary form must reproduce the above copyright notice, 
+;    this list of conditions and the following disclaimer in the documentation 
+;    and/or other materials provided with the distribution.
+;
+;    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
+;    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+;    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS 
+;    BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+;    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+;    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+;    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+;    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+;    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+;    THE POSSIBILITY OF SUCH DAMAGE.
+
+; Slave settings
+.equ I2C_SLAVE_ADDRESS         = 0x42
+
+; USICR - Control Register values
+.equ I2C_IDLE                  = 0b10101000
+.equ I2C_ACTIVE                = 0b11111000
+
+; USISR - Status register values
+.equ I2C_CLEAR_STARTFLAG       = 0b10000000
+.equ I2C_COUNT_BYTE            = 0b01110000
+.equ I2C_COUNT_BIT             = 0b01111110
+
+;******************************************************************************
+; Function...: i2c_main
+; Description: I2C main function
+; In.........: Nothing
+; Out........: Nothing
+i2c_main:
+    ; Pin setup
+    cbi DDRB,I2C_SDA                ; SDA as input
+    sbi DDRB,I2C_CLK                ; CLK as output, don't touch!
+    sbi PORTB,I2C_SDA               ; SDA = high, don't touch!
+    sbi PORTB,I2C_CLK               ; CLK = high, don't touch!
+
+    ; Fallthrough to i2c_reset
+
+;******************************************************************************
+; Function...: i2c_reset
+; Description: USI control & status register setup, then waits for start/stop
+;              condition
+; In.........: Nothing
+; Out........: Nothing
+i2c_reset:
+    ; USI control & status register setup
+    ldi r16, I2C_IDLE
+    out USICR,r16
+    ldi r16, I2C_COUNT_BYTE
+    out USISR,r16
+    
+    ; Wait for start/stop condition
+    rcall i2c_poll
+    
+    ; i2c_poll is guaranteed not to return here (OVF not active)
+
+;******************************************************************************
+; Function...: i2c_start
+; Description: Handles I2C start/stop conditions
+; In.........: Nothing
+; Out........: Nothing
+i2c_start:
+    ; Pin setup
+    cbi DDRB,I2C_SDA                ; SDA as input
+
+i2c_start2:
+    ; Wait for CLK low (=start condition) or SDA high (=stop condition)
+    in r16,PINB
+    andi r16,(1<<I2C_CLK) | (1<<I2C_SDA)
+    cpi r16, (1<<I2C_CLK) | (0<<I2C_SDA)
+    breq i2c_start2
+
+    sbrc r16, I2C_CLK
+    rjmp i2c_reset                  ; Stop condition
+
+    ; Fallthrough to i2c_check_address
+
+;******************************************************************************
+; Function...: i2c_check_address
+; Description: Check address match
+; In.........: Nothing
+; Out........: Nothing
+i2c_check_address:
+    ; Configure to read one byte
+    ldi r16, I2C_ACTIVE
+    out USICR, r16
+    ldi r16, (I2C_CLEAR_STARTFLAG | I2C_COUNT_BYTE)
+    out USISR, r16
+
+    ; Wait for I2C overflow condition
+    rcall i2c_poll
+
+    ; Get address + R/W bit
+    in r16, USIDR
+    mov r17, r16                        ; Copy address + R/W to r17
+
+    ; Compare address
+    lsr r16
+    cpi r16, I2C_SLAVE_ADDRESS
+    brne i2c_reset
+
+    ; Store DDR bit
+    mov i2c_ddr, r17
+
+    ; Clear internal offset/command if master write
+    sbrs i2c_ddr, 0
+    clr i2c_command
+
+    ; Fallthrough to i2c_send_ack
+
+;******************************************************************************
+; Function...: i2c_send_ack
+; Description: Sends ack bit to master
+; In.........: Nothing
+; Out........: Nothing
+i2c_send_ack:
+    ; Clear Data Register bit 7 to send ACK
+    cbi USIDR, 7
+    
+    ; Configure to send one bit
+    sbi DDRB, I2C_SDA
+    ldi r16, I2C_COUNT_BIT
+    out USISR, r16
+
+    ; Wait for I2C overflow condition
+    rcall i2c_poll
+
+    ; Select receive or transmit
+    sbrc i2c_ddr, 0
+    rjmp i2c_transmit
+
+    ; Fallthrough to i2c_receive
+
+;******************************************************************************
+; Function...: i2c_receive
+; Description: Receives one byte sent by the master
+; In.........: Nothing
+; Out........: Nothing
+i2c_receive:    
+    ; Configure to read a byte
+    cbi DDRB, I2C_SDA
+    ldi r16, I2C_COUNT_BYTE
+    out USISR, r16
+
+    ; Wait for I2C overflow condition
+    rcall i2c_poll
+
+    ; Get byte from Data Register
+    in r16, USIDR
+
+    ; Set command, if not previously set
+    cpi i2c_command, 0
+    brne i2c_receive2
+    mov i2c_command, r16
+    
+    ; Reboot command
+    cpi i2c_command, 0x82
+    brne i2c_send_ack
+    CMD_REBOOT                          ; Guaranteed not to return
+
+i2c_receive2:
+    cpi i2c_command, 0x80
+    brne i2c_receive3
+    CMD_RECEIVE_PACKET
+
+i2c_receive3:
+    cpi i2c_command, 0x84
+    brne i2c_receive4
+    CMD_REWIND_TARGET_ADDR
+
+i2c_receive4:
+    clr i2c_command
+    rjmp i2c_send_ack
+
+
+;******************************************************************************
+; Function...: i2c_transmit
+; Description: Transmits one byte to the master
+; In.........: Nothing
+; Out........: Nothing
+i2c_transmit:
+    ; Load default value
+    ldi r17, 0x00
+
+    ; Command 0x81 - Commit
+    cpi i2c_command,0x81
+    brne i2c_transmit2
+    CMD_COMMIT
+
+i2c_transmit2:
+    ; Command 0x83 - Get version
+    cpi i2c_command, 0x83
+    brne i2c_transmit3
+    CMD_GET_VERSION
+
+i2c_transmit3:
+    ; Command 0x85 - Read flash
+    cpi i2c_command, 0x85
+    brne i2c_transmit4
+    CMD_READ_FLASH
+
+i2c_transmit4:
+    ; Store value in data register
+    out USIDR, r17
+
+    ; Configure to send one byte
+    sbi DDRB, I2C_SDA
+    ldi r16, I2C_COUNT_BYTE
+    out USISR, r16
+
+    ; Clear command
+    clr i2c_command
+    
+    ; Wait for I2C overflow condition
+    rcall i2c_poll
+
+    ; Configure to read master response (ACK/NACK)
+    cbi DDRB, I2C_SDA
+    ldi r16, I2C_COUNT_BIT
+    out USISR, r16
+    
+    ; Wait for I2C overflow condition
+    rcall i2c_poll
+
+    ; Get master response (ACK/NACK)
+    sbic USIDR, 0
+    rjmp i2c_reset                      ; NACK
+    rjmp i2c_transmit                   ; ACK
+
+;******************************************************************************
+; Function...: i2c_poll
+; Description: Polls I2C status flags until start/stop or overflow occurs
+; In.........: Nothing
+; Out........: Nothing
+i2c_poll:
+    ; Overflow flag
+    sbic USISR, 6
+    ret
+
+    ; Start flag
+    sbis USISR, 7
+    rjmp i2c_poll
+
+i2c_poll2:
+    pop r16
+    pop r16
+    rjmp i2c_start

--- a/bootloader/license
+++ b/bootloader/license
@@ -1,0 +1,24 @@
+
+Copyright 2023-2024 Stefan Jakobsson
+ 
+Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this 
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, 
+this list of conditions and the following disclaimer in the documentation 
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS 
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+THE POSSIBILITY OF SUCH DAMAGE.

--- a/bootloader/main.asm
+++ b/bootloader/main.asm
@@ -1,0 +1,138 @@
+; Copyright 2023-2024 Stefan Jakobsson
+; 
+; Redistribution and use in source and binary forms, with or without modification, 
+; are permitted provided that the following conditions are met:
+;
+; 1. Redistributions of source code must retain the above copyright notice, this 
+;    list of conditions and the following disclaimer.
+;
+; 2. Redistributions in binary form must reproduce the above copyright notice, 
+;    this list of conditions and the following disclaimer in the documentation 
+;    and/or other materials provided with the distribution.
+;
+;    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
+;    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+;    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS 
+;    BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+;    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+;    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+;    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+;    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+;    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+;    THE POSSIBILITY OF SUCH DAMAGE.
+
+; Definitions
+.include "tn861def.inc"
+.include "pins.inc"
+.include "registers.inc"
+
+; Macros
+.include "command.inc"
+
+.cseg
+
+.org 0xf00
+
+;******************************************************************************
+; Bootloader jump table
+rjmp main                   ; Byte address: 0x1e00
+rjmp update_firmware        ; Byte address: 0x1e02
+
+;******************************************************************************
+; Function...: main
+; Description: Bootloader main entry
+; In.........: Nothing
+; Out........: Nothing
+main:
+    ; Disable interrupts
+    cli
+    
+    ; Disable watchdog timer
+    wdr
+    ldi r16, 0
+    out MCUSR, r16
+    in r16, WDTCSR
+    ori r16, (1<<WDCE) | (1<<WDE)
+    out WDTCSR, r16
+    ldi r16, 0
+    out WDTCSR, r16
+
+    ; Configure Reset button pin (PB4) as input pullup
+    cbi DDRB, RESET_BTN
+    sbi PORTB, RESET_BTN
+    
+    ; Short delay, approx 48 us
+    ldi r16, 0xff
+main2:
+    dec r16
+    brne main2
+    
+    ; Jump to firmware start vector, stored in EE_RDY (=ERDYaddr),
+    ; if Reset button is not pressed (high)
+    sbic PINB, RESET_BTN
+    rjmp ERDYaddr
+    
+    ; Else fallthrough to power_on_seq
+
+;******************************************************************************
+; Function...: power_on_seq
+; Description: System power on sequence
+; In.........: Nothing
+; Out........: Nothing
+power_on_seq:
+    ; Assert RESB
+    sbi DDRA, RESB
+    cbi PORTA, RESB
+
+    ; Turn on PSU
+    sbi DDRA, PWR_ON
+    cbi PORTA, PWR_ON
+
+    ; RESB hold time 500 ms
+    ldi r18, 0x29
+    ldi r17, 0xff
+    ldi r16, 0xff
+resb_hold_delay:
+    dec r16
+    brne resb_hold_delay
+    dec r17
+    brne resb_hold_delay
+    dec r18
+    brne resb_hold_delay
+
+    ; Deassert RESB
+    cbi DDRA, RESB
+
+    ; Fallthrough to update_firmware
+
+;******************************************************************************
+; Function...: update_firmware
+; Description: Starts firmare update procedure
+; In.........: Nothing
+; Out........: Nothing
+update_firmware:
+    ; Disable interrupts
+    cli
+
+    ; Set stack pointer to end of SRAM
+    ldi r16, low(RAMEND)
+    out SPL, r16
+    ldi r16, high(RAMEND)
+    out SPH, r16
+
+    ; Setup
+    clr zeroL
+    clr zeroH
+    rcall flash_clear_buf
+    movw checksum:packet_size, zeroH:zeroL
+    movw target_addrH:target_addrL, zeroH:zeroL
+    clr packet_count
+    clr chip_erased
+
+    ; Start I2C
+    rjmp i2c_main
+
+.include "flash.asm"
+.include "i2c.asm"
+.include "version.asm"

--- a/bootloader/pins.inc
+++ b/bootloader/pins.inc
@@ -1,0 +1,32 @@
+; Copyright 2023-2024 Stefan Jakobsson
+; 
+; Redistribution and use in source and binary forms, with or without modification, 
+; are permitted provided that the following conditions are met:
+;
+; 1. Redistributions of source code must retain the above copyright notice, this 
+;    list of conditions and the following disclaimer.
+;
+; 2. Redistributions in binary form must reproduce the above copyright notice, 
+;    this list of conditions and the following disclaimer in the documentation 
+;    and/or other materials provided with the distribution.
+;
+;    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
+;    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+;    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS 
+;    BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+;    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+;    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+;    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+;    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+;    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+;    THE POSSIBILITY OF SUCH DAMAGE.
+
+; Port A
+.equ RESB                = 0
+.equ PWR_ON              = 5
+
+; Port B
+.equ I2C_SDA             = 0
+.equ I2C_CLK             = 2
+.equ RESET_BTN           = 4

--- a/bootloader/registers.inc
+++ b/bootloader/registers.inc
@@ -1,0 +1,51 @@
+; Copyright 2023-2024 Stefan Jakobsson
+; 
+; Redistribution and use in source and binary forms, with or without modification, 
+; are permitted provided that the following conditions are met:
+;
+; 1. Redistributions of source code must retain the above copyright notice, this 
+;    list of conditions and the following disclaimer.
+;
+; 2. Redistributions in binary form must reproduce the above copyright notice, 
+;    this list of conditions and the following disclaimer in the documentation 
+;    and/or other materials provided with the distribution.
+;
+;    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
+;    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+;    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS 
+;    BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+;    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+;    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+;    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+;    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+;    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+;    THE POSSIBILITY OF SUCH DAMAGE.
+
+
+; r0-r1 reserved for special use (SPM buffer copy)
+
+.def packet_tailL                  = r2       ; Pointer to current RAM buffer tail
+.def packet_tailH                  = r3
+.def chip_erased                   = r4
+
+; r5-r13 free
+
+.def zeroL                         = r14
+.def zeroH                         = r15
+
+; r16-r19 reserved for temporary use
+
+.def packet_size                   = r20      ; Current packet size
+.def checksum                      = r21      ; Current packet checksum
+.def packet_count                  = r22            
+.def i2c_state                     = r23      ; For the I2C state machine
+.def i2c_ddr                       = r24      ; Current data direction
+.def i2c_command                   = r25      ; Current I2C command
+
+; X (26-r27)
+
+.def packet_headL                  = r28
+.def packet_headH                  = r29
+.def target_addrL                  = r30
+.def target_addrH                  = r31

--- a/bootloader/resources/README.TXT
+++ b/bootloader/resources/README.TXT
@@ -1,0 +1,1 @@
+Place the firmware hex file (x16-smc.ino.hex) in this folder

--- a/bootloader/scripts/convert_hex2bin.py
+++ b/bootloader/scripts/convert_hex2bin.py
@@ -1,0 +1,5 @@
+from intelhex import IntelHex
+
+bootloader = IntelHex()
+bootloader.fromfile("build/bootloader.hex", format="hex")
+bootloader.tofile("build/bootloader.bin", format="bin")

--- a/bootloader/scripts/merge_firmware_and_bootloader.py
+++ b/bootloader/scripts/merge_firmware_and_bootloader.py
@@ -1,0 +1,36 @@
+import sys
+from intelhex import IntelHex
+
+# Load firmware
+try:
+    firmware = IntelHex()
+    firmware.fromfile("resources/x16-smc.ino.hex", format="hex")
+except:
+    print("Error loading firmware")
+    quit()
+
+# Load bootloader
+try:
+    bootloader = IntelHex()
+    bootloader.fromfile("build/bootloader.hex", format="hex")
+except:
+    print("Error loading bootloader")
+    quit()
+
+# Move firmware's original reset vector (byte addr 0x00) to EE_RDY (byte addr 0x12)
+orig_reset = firmware[0x00] + firmware[0x01] * 256
+orig_reset = (((orig_reset - 9) & 0b1100111111111111) | 0b1100000000000000)
+firmware[0x12] = orig_reset & 255
+firmware[0x13] = orig_reset >> 8
+
+# Set reset vector to opcode for "rjmp 0x1e00" (start of bootloader)
+firmware[0x00] = 0xff
+firmware[0x01] = 0xce
+
+# Merge firmware and bootloader into new file
+try:
+    firmware.merge(bootloader, overlap="error")
+    firmware.tofile("build/firmware_with_bootloader.hex", format="hex")
+except:
+    print("Merge error")
+    quit()

--- a/bootloader/tn861def.inc
+++ b/bootloader/tn861def.inc
@@ -1,0 +1,815 @@
+;***** THIS IS A MACHINE GENERATED FILE - DO NOT EDIT ********************
+;***** Created: 2011-02-09 12:04 ******* Source: ATtiny861.xml ***********
+;*************************************************************************
+;* A P P L I C A T I O N   N O T E   F O R   T H E   A V R   F A M I L Y
+;* 
+;* Number            : AVR000
+;* File Name         : "tn861def.inc"
+;* Title             : Register/Bit Definitions for the ATtiny861
+;* Date              : 2011-02-09
+;* Version           : 2.35
+;* Support E-mail    : avr@atmel.com
+;* Target MCU        : ATtiny861
+;* 
+;* DESCRIPTION
+;* When including this file in the assembly program file, all I/O register 
+;* names and I/O register bit names appearing in the data book can be used.
+;* In addition, the six registers forming the three data pointers X, Y and 
+;* Z have been assigned names XL - ZH. Highest RAM address for Internal 
+;* SRAM is also defined 
+;* 
+;* The Register names are represented by their hexadecimal address.
+;* 
+;* The Register Bit names are represented by their bit number (0-7).
+;* 
+;* Please observe the difference in using the bit names with instructions
+;* such as "sbr"/"cbr" (set/clear bit in register) and "sbrs"/"sbrc"
+;* (skip if bit in register set/cleared). The following example illustrates
+;* this:
+;* 
+;* in    r16,PORTB             ;read PORTB latch
+;* sbr   r16,(1<<PB6)+(1<<PB5) ;set PB6 and PB5 (use masks, not bit#)
+;* out   PORTB,r16             ;output to PORTB
+;* 
+;* in    r16,TIFR              ;read the Timer Interrupt Flag Register
+;* sbrc  r16,TOV0              ;test the overflow flag (use bit#)
+;* rjmp  TOV0_is_set           ;jump if set
+;* ...                         ;otherwise do something else
+;*************************************************************************
+
+#ifndef _TN861DEF_INC_
+#define _TN861DEF_INC_
+
+
+#pragma partinc 0
+
+; ***** SPECIFY DEVICE ***************************************************
+.device ATtiny861A
+#pragma AVRPART ADMIN PART_NAME ATtiny861
+.equ	SIGNATURE_000	= 0x1e
+.equ	SIGNATURE_001	= 0x93
+.equ	SIGNATURE_002	= 0x0d
+
+#pragma AVRPART CORE CORE_VERSION V2
+#pragma AVRPART CORE NEW_INSTRUCTIONS lpm rd,z+
+
+
+; ***** I/O REGISTER DEFINITIONS *****************************************
+; NOTE:
+; Definitions marked "MEMORY MAPPED"are extended I/O ports
+; and cannot be used with IN/OUT instructions
+.equ	SREG	= 0x3f
+.equ	SPL	= 0x3d
+.equ	SPH	= 0x3e
+.equ	GIMSK	= 0x3b
+.equ	GIFR	= 0x3a
+.equ	TIMSK	= 0x39
+.equ	TIFR	= 0x38
+.equ	SPMCSR	= 0x37
+.equ	PRR	= 0x36
+.equ	MCUCR	= 0x35
+.equ	MCUSR	= 0x34
+.equ	TCCR0B	= 0x33
+.equ	TCNT0L	= 0x32
+.equ	OSCCAL	= 0x31
+.equ	TCCR1A	= 0x30
+.equ	TCCR1B	= 0x2f
+.equ	TCNT1	= 0x2e
+.equ	OCR1A	= 0x2d
+.equ	OCR1B	= 0x2c
+.equ	OCR1C	= 0x2b
+.equ	OCR1D	= 0x2a
+.equ	PLLCSR	= 0x29
+.equ	CLKPR	= 0x28
+.equ	TCCR1C	= 0x27
+.equ	TCCR1D	= 0x26
+.equ	TC1H	= 0x25
+.equ	DT1	= 0x24
+.equ	PCMSK0	= 0x23
+.equ	PCMSK1	= 0x22
+.equ	WDTCR	= 0x21
+.equ	DWDR	= 0x20
+.equ	EEARH	= 0x1f
+.equ	EEARL	= 0x1e
+.equ	EEDR	= 0x1d
+.equ	EECR	= 0x1c
+.equ	PORTA	= 0x1b
+.equ	DDRA	= 0x1a
+.equ	PINA	= 0x19
+.equ	PORTB	= 0x18
+.equ	DDRB	= 0x17
+.equ	PINB	= 0x16
+.equ	TCCR0A	= 0x15
+.equ	TCNT0H	= 0x14
+.equ	OCR0A	= 0x13
+.equ	OCR0B	= 0x12
+.equ	USIPP	= 0x11
+.equ	USIBR	= 0x10
+.equ	USIDR	= 0x0f
+.equ	USISR	= 0x0e
+.equ	USICR	= 0x0d
+.equ	GPIOR2	= 0x0c
+.equ	GPIOR1	= 0x0b
+.equ	GPIOR0	= 0x0a
+.equ	ACSRB	= 0x09
+.equ	ACSRA	= 0x08
+.equ	ADMUX	= 0x07
+.equ	ADCSRA	= 0x06
+.equ	ADCH	= 0x05
+.equ	ADCL	= 0x04
+.equ	ADCSRB	= 0x03
+.equ	DIDR1	= 0x02
+.equ	DIDR0	= 0x01
+.equ	TCCR1E	= 0x00
+
+
+; ***** BIT DEFINITIONS **************************************************
+
+; ***** PORTA ************************
+; PORTA - Port A Data Register
+.equ	PORTA0	= 0	; Port A Data Register bit 0
+.equ	PA0	= 0	; For compatibility
+.equ	PORTA1	= 1	; Port A Data Register bit 1
+.equ	PA1	= 1	; For compatibility
+.equ	PORTA2	= 2	; Port A Data Register bit 2
+.equ	PA2	= 2	; For compatibility
+.equ	PORTA3	= 3	; Port A Data Register bit 3
+.equ	PA3	= 3	; For compatibility
+.equ	PORTA4	= 4	; Port A Data Register bit 4
+.equ	PA4	= 4	; For compatibility
+.equ	PORTA5	= 5	; Port A Data Register bit 5
+.equ	PA5	= 5	; For compatibility
+.equ	PORTA6	= 6	; Port A Data Register bit 6
+.equ	PA6	= 6	; For compatibility
+.equ	PORTA7	= 7	; Port A Data Register bit 7
+.equ	PA7	= 7	; For compatibility
+
+; DDRA - Port A Data Direction Register
+.equ	DDA0	= 0	; Data Direction Register, Port A, bit 0
+.equ	DDA1	= 1	; Data Direction Register, Port A, bit 1
+.equ	DDA2	= 2	; Data Direction Register, Port A, bit 2
+.equ	DDA3	= 3	; Data Direction Register, Port A, bit 3
+.equ	DDA4	= 4	; Data Direction Register, Port A, bit 4
+.equ	DDA5	= 5	; Data Direction Register, Port A, bit 5
+.equ	DDA6	= 6	; Data Direction Register, Port A, bit 6
+.equ	DDA7	= 7	; Data Direction Register, Port A, bit 7
+
+; PINA - Port A Input Pins
+.equ	PINA0	= 0	; Input Pins, Port A bit 0
+.equ	PINA1	= 1	; Input Pins, Port A bit 1
+.equ	PINA2	= 2	; Input Pins, Port A bit 2
+.equ	PINA3	= 3	; Input Pins, Port A bit 3
+.equ	PINA4	= 4	; Input Pins, Port A bit 4
+.equ	PINA5	= 5	; Input Pins, Port A bit 5
+.equ	PINA6	= 6	; Input Pins, Port A bit 6
+.equ	PINA7	= 7	; Input Pins, Port A bit 7
+
+
+; ***** PORTB ************************
+; PORTB - Port B Data Register
+.equ	PORTB0	= 0	; Port B Data Register bit 0
+.equ	PB0	= 0	; For compatibility
+.equ	PORTB1	= 1	; Port B Data Register bit 1
+.equ	PB1	= 1	; For compatibility
+.equ	PORTB2	= 2	; Port B Data Register bit 2
+.equ	PB2	= 2	; For compatibility
+.equ	PORTB3	= 3	; Port B Data Register bit 3
+.equ	PB3	= 3	; For compatibility
+.equ	PORTB4	= 4	; Port B Data Register bit 4
+.equ	PB4	= 4	; For compatibility
+.equ	PORTB5	= 5	; Port B Data Register bit 5
+.equ	PB5	= 5	; For compatibility
+.equ	PORTB6	= 6	; Port B Data Register bit 6
+.equ	PB6	= 6	; For compatibility
+.equ	PORTB7	= 7	; Port B Data Register bit 7
+.equ	PB7	= 7	; For compatibility
+
+; DDRB - Port B Data Direction Register
+.equ	DDB0	= 0	; Port B Data Direction Register bit 0
+.equ	DDB1	= 1	; Port B Data Direction Register bit 1
+.equ	DDB2	= 2	; Port B Data Direction Register bit 2
+.equ	DDB3	= 3	; Port B Data Direction Register bit 3
+.equ	DDB4	= 4	; Port B Data Direction Register bit 4
+.equ	DDB5	= 5	; Port B Data Direction Register bit 5
+.equ	DDB6	= 6	; Port B Data Direction Register bit 6
+.equ	DDB7	= 7	; Port B Data Direction Register bit 7
+
+; PINB - Port B Input Pins
+.equ	PINB0	= 0	; Port B Input Pins bit 0
+.equ	PINB1	= 1	; Port B Input Pins bit 1
+.equ	PINB2	= 2	; Port B Input Pins bit 2
+.equ	PINB3	= 3	; Port B Input Pins bit 3
+.equ	PINB4	= 4	; Port B Input Pins bit 4
+.equ	PINB5	= 5	; Port B Input Pins bit 5
+.equ	PINB6	= 6	; Port B Input Pins bit 6
+.equ	PINB7	= 7	; Port B Input Pins bit 7
+
+
+; ***** AD_CONVERTER *****************
+; ADMUX - The ADC multiplexer Selection Register
+.equ	MUX0	= 0	; Analog Channel and Gain Selection Bits
+.equ	MUX1	= 1	; Analog Channel and Gain Selection Bits
+.equ	MUX2	= 2	; Analog Channel and Gain Selection Bits
+.equ	MUX3	= 3	; Analog Channel and Gain Selection Bits
+.equ	MUX4	= 4	; Analog Channel and Gain Selection Bits
+.equ	ADLAR	= 5	; Left Adjust Result
+.equ	REFS0	= 6	; Reference Selection Bit 0
+.equ	REFS1	= 7	; Reference Selection Bit 1
+
+; ADCSRA - The ADC Control and Status register
+.equ	ADPS0	= 0	; ADC Prescaler Select Bits
+.equ	ADPS1	= 1	; ADC Prescaler Select Bits
+.equ	ADPS2	= 2	; ADC Prescaler Select Bits
+.equ	ADIE	= 3	; ADC Interrupt Enable
+.equ	ADIF	= 4	; ADC Interrupt Flag
+.equ	ADATE	= 5	; ADC Auto Trigger Enable
+.equ	ADSC	= 6	; ADC Start Conversion
+.equ	ADEN	= 7	; ADC Enable
+
+; ADCH - ADC Data Register High Byte
+.equ	ADCH0	= 0	; ADC Data Register High Byte Bit 0
+.equ	ADCH1	= 1	; ADC Data Register High Byte Bit 1
+.equ	ADCH2	= 2	; ADC Data Register High Byte Bit 2
+.equ	ADCH3	= 3	; ADC Data Register High Byte Bit 3
+.equ	ADCH4	= 4	; ADC Data Register High Byte Bit 4
+.equ	ADCH5	= 5	; ADC Data Register High Byte Bit 5
+.equ	ADCH6	= 6	; ADC Data Register High Byte Bit 6
+.equ	ADCH7	= 7	; ADC Data Register High Byte Bit 7
+
+; ADCL - ADC Data Register Low Byte
+.equ	ADCL0	= 0	; ADC Data Register Low Byte Bit 0
+.equ	ADCL1	= 1	; ADC Data Register Low Byte Bit 1
+.equ	ADCL2	= 2	; ADC Data Register Low Byte Bit 2
+.equ	ADCL3	= 3	; ADC Data Register Low Byte Bit 3
+.equ	ADCL4	= 4	; ADC Data Register Low Byte Bit 4
+.equ	ADCL5	= 5	; ADC Data Register Low Byte Bit 5
+.equ	ADCL6	= 6	; ADC Data Register Low Byte Bit 6
+.equ	ADCL7	= 7	; ADC Data Register Low Byte Bit 7
+
+; ADCSRB - ADC Control and Status Register B
+.equ	ADTS0	= 0	; ADC Auto Trigger Source 0
+.equ	ADTS1	= 1	; ADC Auto Trigger Source 1
+.equ	ADTS2	= 2	; ADC Auto Trigger Source 2
+.equ	MUX5	= 3	; 
+.equ	REFS2	= 4	; 
+.equ	IPR	= 5	; Input Polarity Mode
+.equ	GSEL	= 6	; Gain Select
+.equ	BIN	= 7	; Bipolar Input Mode
+
+; DIDR0 - Digital Input Disable Register 0
+.equ	ADC0D	= 0	; ADC0 Digital input Disable
+.equ	ADC1D	= 1	; ADC1 Digital input Disable
+.equ	ADC2D	= 2	; ADC2 Digital input Disable
+.equ	AREFD	= 3	; AREF Digital Input Disable
+.equ	ADC3D	= 4	; ADC3 Digital input Disable
+.equ	ADC4D	= 5	; ADC4 Digital input Disable
+.equ	ADC5D	= 6	; ADC5 Digital input Disable
+.equ	ADC6D	= 7	; ADC6 Digital input Disable
+
+; DIDR1 - Digital Input Disable Register 1
+.equ	ADC7D	= 4	; ADC7 Digital input Disable
+.equ	ADC8D	= 5	; ADC8 Digital input Disable
+.equ	ADC9D	= 6	; ADC9 Digital input Disable
+.equ	ADC10D	= 7	; ADC10 Digital input Disable
+
+
+; ***** ANALOG_COMPARATOR ************
+; ACSRA - Analog Comparator Control And Status Register A
+.equ	ACIS0	= 0	; Analog Comparator Interrupt Mode Select bit 0
+.equ	ACIS1	= 1	; Analog Comparator Interrupt Mode Select bit 1
+.equ	ACME	= 2	; Analog Comparator Multiplexer Enable
+.equ	ACIE	= 3	; Analog Comparator Interrupt Enable
+.equ	ACI	= 4	; Analog Comparator Interrupt Flag
+.equ	ACO	= 5	; Analog Compare Output
+.equ	ACBG	= 6	; Analog Comparator Bandgap Select
+.equ	ACD	= 7	; Analog Comparator Disable
+
+; ACSRB - Analog Comparator Control And Status Register B
+.equ	ACM0	= 0	; Analog Comparator Multiplexer
+.equ	ACM1	= 1	; Analog Comparator Multiplexer
+.equ	ACM2	= 2	; Analog Comparator Multiplexer
+.equ	HLEV	= 6	; Hysteresis Level
+.equ	HSEL	= 7	; Hysteresis Select
+
+
+; ***** USI **************************
+; USIPP - USI Pin Position
+.equ	USIPOS	= 0	; USI Pin Position
+
+; USIBR - USI Buffer Register
+.equ	USIBR0	= 0	; USI Buffer Register bit 0
+.equ	USIBR1	= 1	; USI Buffer Register bit 1
+.equ	USIBR2	= 2	; USI Buffer Register bit 2
+.equ	USIBR3	= 3	; USI Buffer Register bit 3
+.equ	USIBR4	= 4	; USI Buffer Register bit 4
+.equ	USIBR5	= 5	; USI Buffer Register bit 5
+.equ	USIBR6	= 6	; USI Buffer Register bit 6
+.equ	USIBR7	= 7	; USI Buffer Register bit 7
+
+; USIDR - USI Data Register
+.equ	USIDR0	= 0	; USI Data Register bit 0
+.equ	USIDR1	= 1	; USI Data Register bit 1
+.equ	USIDR2	= 2	; USI Data Register bit 2
+.equ	USIDR3	= 3	; USI Data Register bit 3
+.equ	USIDR4	= 4	; USI Data Register bit 4
+.equ	USIDR5	= 5	; USI Data Register bit 5
+.equ	USIDR6	= 6	; USI Data Register bit 6
+.equ	USIDR7	= 7	; USI Data Register bit 7
+
+; USISR - USI Status Register
+.equ	USICNT0	= 0	; USI Counter Value Bit 0
+.equ	USICNT1	= 1	; USI Counter Value Bit 1
+.equ	USICNT2	= 2	; USI Counter Value Bit 2
+.equ	USICNT3	= 3	; USI Counter Value Bit 3
+.equ	USIDC	= 4	; Data Output Collision
+.equ	USIPF	= 5	; Stop Condition Flag
+.equ	USIOIF	= 6	; Counter Overflow Interrupt Flag
+.equ	USISIF	= 7	; Start Condition Interrupt Flag
+
+; USICR - USI Control Register
+.equ	USITC	= 0	; Toggle Clock Port Pin
+.equ	USICLK	= 1	; Clock Strobe
+.equ	USICS0	= 2	; USI Clock Source Select Bit 0
+.equ	USICS1	= 3	; USI Clock Source Select Bit 1
+.equ	USIWM0	= 4	; USI Wire Mode Bit 0
+.equ	USIWM1	= 5	; USI Wire Mode Bit 1
+.equ	USIOIE	= 6	; Counter Overflow Interrupt Enable
+.equ	USISIE	= 7	; Start Condition Interrupt Enable
+
+
+; ***** EEPROM ***********************
+; EEARL - EEPROM Address Register Low Byte
+.equ	EEAR0	= 0	; EEPROM Read/Write Access Bit 0
+.equ	EEAR1	= 1	; EEPROM Read/Write Access Bit 1
+.equ	EEAR2	= 2	; EEPROM Read/Write Access Bit 2
+.equ	EEAR3	= 3	; EEPROM Read/Write Access Bit 3
+.equ	EEAR4	= 4	; EEPROM Read/Write Access Bit 4
+.equ	EEAR5	= 5	; EEPROM Read/Write Access Bit 5
+.equ	EEAR6	= 6	; EEPROM Read/Write Access Bit 6
+.equ	EEAR7	= 7	; EEPROM Read/Write Access Bit 7
+
+; EEARH - EEPROM Address Register High Byte
+.equ	EEAR8	= 0	; EEPROM Read/Write Access Bit 0
+
+; EEDR - EEPROM Data Register
+.equ	EEDR0	= 0	; EEPROM Data Register bit 0
+.equ	EEDR1	= 1	; EEPROM Data Register bit 1
+.equ	EEDR2	= 2	; EEPROM Data Register bit 2
+.equ	EEDR3	= 3	; EEPROM Data Register bit 3
+.equ	EEDR4	= 4	; EEPROM Data Register bit 4
+.equ	EEDR5	= 5	; EEPROM Data Register bit 5
+.equ	EEDR6	= 6	; EEPROM Data Register bit 6
+.equ	EEDR7	= 7	; EEPROM Data Register bit 7
+
+; EECR - EEPROM Control Register
+.equ	EERE	= 0	; EEPROM Read Enable
+.equ	EEPE	= 1	; EEPROM Write Enable
+.equ	EEMPE	= 2	; EEPROM Master Write Enable
+.equ	EERIE	= 3	; EEPROM Ready Interrupt Enable
+.equ	EEPM0	= 4	; EEPROM Programming Mode Bit 0
+.equ	EEPM1	= 5	; EEPROM Programming Mode Bit 1
+
+
+; ***** WATCHDOG *********************
+; WDTCR - Watchdog Timer Control Register
+.equ	WDTCSR	= WDTCR	; For compatibility
+.equ	WDP0	= 0	; Watch Dog Timer Prescaler bit 0
+.equ	WDP1	= 1	; Watch Dog Timer Prescaler bit 1
+.equ	WDP2	= 2	; Watch Dog Timer Prescaler bit 2
+.equ	WDE	= 3	; Watch Dog Enable
+.equ	WDCE	= 4	; Watchdog Change Enable
+.equ	WDTOE	= WDCE	; For compatibility
+.equ	WDP3	= 5	; Watchdog Timer Prescaler Bit 3
+.equ	WDIE	= 6	; Watchdog Timeout Interrupt Enable
+.equ	WDIF	= 7	; Watchdog Timeout Interrupt Flag
+
+
+; ***** TIMER_COUNTER_0 **************
+; TIMSK - Timer/Counter Interrupt Mask Register
+.equ	TICIE0	= 0	; Timer/Counter0 Input Capture Interrupt Enable
+.equ	TOIE0	= 1	; Timer/Counter0 Overflow Interrupt Enable
+.equ	OCIE0B	= 3	; Timer/Counter0 Output Compare Match B Interrupt Enable
+.equ	OCIE0A	= 4	; Timer/Counter0 Output Compare Match A Interrupt Enable
+
+; TIFR - Timer/Counter0 Interrupt Flag register
+.equ	ICF0	= 0	; Timer/Counter0 Input Capture Flag
+.equ	TOV0	= 1	; Timer/Counter0 Overflow Flag
+.equ	OCF0B	= 3	; Timer/Counter0 Output Compare Flag 0B
+.equ	OCF0A	= 4	; Timer/Counter0 Output Compare Flag 0A
+
+; TCCR0A - Timer/Counter  Control Register A
+.equ	WGM00	= 0	; Waveform Generation Mode
+.equ	ACIC0	= 3	; Analog Comparator Input Capture Enable
+.equ	ICES0	= 4	; Input Capture Edge Select
+.equ	ICNC0	= 5	; Input Capture Noice Canceler
+.equ	ICEN0	= 6	; Input Capture Mode Enable
+.equ	TCW0	= 7	; Timer/Counter 0 Width
+
+; TCCR0B - Timer/Counter Control Register B
+.equ	CS00	= 0	; Clock Select
+.equ	CS01	= 1	; Clock Select
+.equ	CS02	= 2	; Clock Select
+.equ	PSR0	= 3	; Timer/Counter 0 Prescaler Reset
+.equ	TSM	= 4	; Timer/Counter Synchronization Mode
+
+; TCNT0H - Timer/Counter0 High
+.equ	TCNT0H_0	= 0	; 
+.equ	TCNT0H_1	= 1	; 
+.equ	TCNT0H_2	= 2	; 
+.equ	TCNT0H_3	= 3	; 
+.equ	TCNT0H_4	= 4	; 
+.equ	TCNT0H_5	= 5	; 
+.equ	TCNT0H_6	= 6	; 
+.equ	TCNT0H_7	= 7	; 
+
+; TCNT0L - Timer/Counter0 Low
+.equ	TCNT0L_0	= 0	; 
+.equ	TCNT0L_1	= 1	; 
+.equ	TCNT0L_2	= 2	; 
+.equ	TCNT0L_3	= 3	; 
+.equ	TCNT0L_4	= 4	; 
+.equ	TCNT0L_5	= 5	; 
+.equ	TCNT0L_6	= 6	; 
+.equ	TCNT0L_7	= 7	; 
+
+; OCR0A - Timer/Counter0 Output Compare Register
+.equ	OCR0A_0	= 0	; 
+.equ	OCR0A_1	= 1	; 
+.equ	OCR0A_2	= 2	; 
+.equ	OCR0A_3	= 3	; 
+.equ	OCR0A_4	= 4	; 
+.equ	OCR0A_5	= 5	; 
+.equ	OCR0A_6	= 6	; 
+.equ	OCR0A_7	= 7	; 
+
+; OCR0B - Timer/Counter0 Output Compare Register
+.equ	OCR0B_0	= 0	; 
+.equ	OCR0B_1	= 1	; 
+.equ	OCR0B_2	= 2	; 
+.equ	OCR0B_3	= 3	; 
+.equ	OCR0B_4	= 4	; 
+.equ	OCR0B_5	= 5	; 
+.equ	OCR0B_6	= 6	; 
+.equ	OCR0B_7	= 7	; 
+
+
+; ***** TIMER_COUNTER_1 **************
+; TCCR1A - Timer/Counter Control Register A
+.equ	PWM1B	= 0	; Pulse Width Modulator Enable
+.equ	PWM1A	= 1	; Pulse Width Modulator Enable
+.equ	FOC1B	= 2	; Force Output Compare Match 1B
+.equ	FOC1A	= 3	; Force Output Compare Match 1A
+.equ	COM1B0	= 4	; Compare Output Mode, Bit 0
+.equ	COM1B1	= 5	; Compare Output Mode, Bit 1
+.equ	COM1A0	= 6	; Compare Output Mode, Bit 1
+.equ	COM1A1	= 7	; Compare Output Mode, Bit 0
+
+; TCCR1B - Timer/Counter Control Register B
+.equ	CS10	= 0	; Clock Select Bits
+.equ	CS11	= 1	; Clock Select Bits
+.equ	CS12	= 2	; Clock Select Bits
+.equ	CS13	= 3	; Clock Select Bits
+.equ	DTPS10	= 4	; Dead Time Prescaler
+.equ	DTPS11	= 5	; Dead Time Prescaler
+.equ	PSR1	= 6	; Timer/Counter 1 Prescaler reset
+
+; TCCR1C - Timer/Counter Control Register C
+.equ	PWM1D	= 0	; Pulse Width Modulator D Enable
+.equ	FOC1D	= 1	; Force Output Compare Match 1D
+.equ	COM1D0	= 2	; Comparator D output mode
+.equ	COM1D1	= 3	; Comparator D output mode
+.equ	COM1B0S	= 4	; COM1B0 Shadow Bit
+.equ	COM1B1S	= 5	; COM1B1 Shadow Bit
+.equ	COM1A0S	= 6	; COM1A0 Shadow Bit
+.equ	COM1A1S	= 7	; COM1A1 Shadow Bit
+
+; TCCR1D - Timer/Counter Control Register D
+.equ	WGM10	= 0	; Waveform Generation Mode Bit
+.equ	WGM11	= 1	; Waveform Generation Mode Bit
+.equ	FPF1	= 2	; Fault Protection Interrupt Flag
+.equ	FPAC1	= 3	; Fault Protection Analog Comparator Enable
+.equ	FPES1	= 4	; Fault Protection Edge Select
+.equ	FPNC1	= 5	; Fault Protection Noise Canceler
+.equ	FPEN1	= 6	; Fault Protection Mode Enable
+.equ	FPIE1	= 7	; Fault Protection Interrupt Enable
+
+; TCCR1E - Timer/Counter1 Control Register E
+.equ	OC1OE0	= 0	; Ouput Compare Override Enable Bit 0
+.equ	OC1OE1	= 1	; Ouput Compare Override Enable Bit 1
+.equ	OC1OE2	= 2	; Ouput Compare Override Enable Bit 2
+.equ	OC1OE3	= 3	; Ouput Compare Override Enable Bit 3
+.equ	OC1OE4	= 4	; Ouput Compare Override Enable Bit 4
+.equ	OC1OE5	= 5	; Ouput Compare Override Enable Bit 5
+
+; TCNT1 - Timer/Counter Register
+.equ	TC1H_0	= 0	; Timer/Counter Register Bit 0
+.equ	TC1H_1	= 1	; Timer/Counter Register Bit 1
+.equ	TC1H_2	= 2	; Timer/Counter Register Bit 2
+.equ	TC1H_3	= 3	; Timer/Counter Register Bit 3
+.equ	TC1H_4	= 4	; Timer/Counter Register Bit 4
+.equ	TC1H_5	= 5	; Timer/Counter Register Bit 5
+.equ	TC1H_6	= 6	; Timer/Counter Register Bit 6
+.equ	TC1H_7	= 7	; Timer/Counter Register Bit 7
+
+; TC1H - Timer/Counter 1 Register High
+.equ	TC18	= 0	; Timer/Counter Register Bit 0
+.equ	TC19	= 1	; Timer/Counter Register Bit 1
+
+; OCR1A - Output Compare Register
+.equ	OCR1A0	= 0	; Output Compare Register A Bit 0
+.equ	OCR1A1	= 1	; Output Compare Register A Bit 1
+.equ	OCR1A2	= 2	; Output Compare Register A Bit 2
+.equ	OCR1A3	= 3	; Output Compare Register A Bit 3
+.equ	OCR1A4	= 4	; Output Compare Register A Bit 4
+.equ	OCR1A5	= 5	; Output Compare Register A Bit 5
+.equ	OCR1A6	= 6	; Output Compare Register A Bit 6
+.equ	OCR1A7	= 7	; Output Compare Register A Bit 7
+
+; OCR1B - Output Compare Register
+.equ	OCR1B0	= 0	; Output Compare Register B Bit 0
+.equ	OCR1B1	= 1	; Output Compare Register B Bit 1
+.equ	OCR1B2	= 2	; Output Compare Register B Bit 2
+.equ	OCR1B3	= 3	; Output Compare Register B Bit 3
+.equ	OCR1B4	= 4	; Output Compare Register B Bit 4
+.equ	OCR1B5	= 5	; Output Compare Register B Bit 5
+.equ	OCR1B6	= 6	; Output Compare Register B Bit 6
+.equ	OCR1B7	= 7	; Output Compare Register B Bit 7
+
+; OCR1C - Output compare register
+.equ	OCR1C0	= 0	; 
+.equ	OCR1C1	= 1	; 
+.equ	OCR1C2	= 2	; 
+.equ	OCR1C3	= 3	; 
+.equ	OCR1C4	= 4	; 
+.equ	OCR1C5	= 5	; 
+.equ	OCR1C6	= 6	; 
+.equ	OCR1C7	= 7	; 
+
+; OCR1D - Output compare register
+.equ	OCR1D0	= 0	; 
+.equ	OCR1D1	= 1	; 
+.equ	OCR1D2	= 2	; 
+.equ	OCR1D3	= 3	; 
+.equ	OCR1D4	= 4	; 
+.equ	OCR1D5	= 5	; 
+.equ	OCR1D6	= 6	; 
+.equ	OCR1D7	= 7	; 
+
+; TIMSK - Timer/Counter Interrupt Mask Register
+.equ	TOIE1	= 2	; Timer/Counter1 Overflow Interrupt Enable
+.equ	OCIE1B	= 5	; OCIE1A: Timer/Counter1 Output Compare B Interrupt Enable
+.equ	OCIE1A	= 6	; OCIE1A: Timer/Counter1 Output Compare Interrupt Enable
+.equ	OCIE1D	= 7	; OCIE1D: Timer/Counter1 Output Compare Interrupt Enable
+
+; TIFR - Timer/Counter Interrupt Flag Register
+.equ	TOV1	= 2	; Timer/Counter1 Overflow Flag
+.equ	OCF1B	= 5	; Timer/Counter1 Output Compare Flag 1B
+.equ	OCF1A	= 6	; Timer/Counter1 Output Compare Flag 1A
+.equ	OCF1D	= 7	; Timer/Counter1 Output Compare Flag 1D
+
+; DT1 - Timer/Counter 1 Dead Time Value
+.equ	DT1L0	= 0	; 
+.equ	DT1L1	= 1	; 
+.equ	DT1L2	= 2	; 
+.equ	DT1L3	= 3	; 
+.equ	DT1H0	= 4	; 
+.equ	DT1H1	= 5	; 
+.equ	DT1H2	= 6	; 
+.equ	DT1H3	= 7	; 
+
+
+; ***** BOOT_LOAD ********************
+; SPMCSR - Store Program Memory Control Register
+.equ	SPMEN	= 0	; Store Program Memory Enable
+.equ	PGERS	= 1	; Page Erase
+.equ	PGWRT	= 2	; Page Write
+.equ	RFLB	= 3	; Read fuse and lock bits
+.equ	CTPB	= 4	; Clear temporary page buffer
+
+
+; ***** EXTERNAL_INTERRUPT ***********
+; MCUCR - MCU Control Register
+.equ	ISC00	= 0	; Interrupt Sense Control 0 Bit 0
+.equ	ISC01	= 1	; Interrupt Sense Control 0 Bit 1
+
+; GIMSK - General Interrupt Mask Register
+.equ	GICR	= GIMSK	; For compatibility
+.equ	PCIE0	= 4	; Pin Change Interrupt Enable 0
+.equ	PCIE1	= 5	; Pin Change Interrupt Enable 1
+.equ	INT0	= 6	; External Interrupt Request 0 Enable
+.equ	INT1	= 7	; External Interrupt Request 1 Enable
+
+; GIFR - General Interrupt Flag register
+.equ	PCIF	= 5	; Pin Change Interrupt Flag
+.equ	INTF0	= 6	; External Interrupt Flag 0
+.equ	INTF1	= 7	; External Interrupt Flag 1
+
+; PCMSK0 - Pin Change Enable Mask 0
+.equ	PCINT0	= 0	; Pin Change Enable Mask Bit 0
+.equ	PCINT1	= 1	; Pin Change Enable Mask Bit 1
+.equ	PCINT2	= 2	; Pin Change Enable Mask Bit 2
+.equ	PCINT3	= 3	; Pin Change Enable Mask Bit 3
+.equ	PCINT4	= 4	; Pin Change Enable Mask Bit 4
+.equ	PCINT5	= 5	; Pin Change Enable Mask Bit 5
+.equ	PCINT6	= 6	; Pin Change Enable Mask Bit 6
+.equ	PCINT7	= 7	; Pin Change Enable Mask Bit 7
+
+; PCMSK1 - Pin Change Enable Mask 1
+.equ	PCINT8	= 0	; Pin Change Enable Mask Bit 8
+.equ	PCINT9	= 1	; Pin Change Enable Mask Bit 9
+.equ	PCINT10	= 2	; Pin Change Enable Mask Bit 10
+.equ	PCINT11	= 3	; Pin Change Enable Mask Bit 11
+.equ	PCINT12	= 4	; Pin Change Enable Mask Bit 12
+.equ	PCINT13	= 5	; Pin Change Enable Mask Bit 13
+.equ	PCINT14	= 6	; Pin Change Enable Mask Bit 14
+.equ	PCINT15	= 7	; Pin Change Enable Mask Bit 15
+
+
+; ***** CPU **************************
+; SREG - Status Register
+.equ	SREG_C	= 0	; Carry Flag
+.equ	SREG_Z	= 1	; Zero Flag
+.equ	SREG_N	= 2	; Negative Flag
+.equ	SREG_V	= 3	; Two's Complement Overflow Flag
+.equ	SREG_S	= 4	; Sign Bit
+.equ	SREG_H	= 5	; Half Carry Flag
+.equ	SREG_T	= 6	; Bit Copy Storage
+.equ	SREG_I	= 7	; Global Interrupt Enable
+
+; MCUCR - MCU Control Register
+;.equ	ISC00	= 0	; Interrupt Sense Control 0 bit 0
+;.equ	ISC01	= 1	; Interrupt Sense Control 0 bit 1
+.equ	SM0	= 3	; Sleep Mode Select Bit 0
+.equ	SM1	= 4	; Sleep Mode Select Bit 1
+.equ	SE	= 5	; Sleep Enable
+.equ	PUD	= 6	; Pull-up Disable
+
+; MCUSR - MCU Status register
+.equ	PORF	= 0	; Power-On Reset Flag
+.equ	EXTRF	= 1	; External Reset Flag
+.equ	BORF	= 2	; Brown-out Reset Flag
+.equ	WDRF	= 3	; Watchdog Reset Flag
+
+; PRR - Power Reduction Register
+.equ	PRADC	= 0	; Power Reduction ADC
+.equ	PRUSI	= 1	; Power Reduction USI
+.equ	PRTIM0	= 2	; Power Reduction Timer/Counter0
+.equ	PRTIM1	= 3	; Power Reduction Timer/Counter1
+
+; OSCCAL - Oscillator Calibration Register
+.equ	CAL0	= 0	; Oscillatro Calibration Value Bit 0
+.equ	CAL1	= 1	; Oscillatro Calibration Value Bit 1
+.equ	CAL2	= 2	; Oscillatro Calibration Value Bit 2
+.equ	CAL3	= 3	; Oscillatro Calibration Value Bit 3
+.equ	CAL4	= 4	; Oscillatro Calibration Value Bit 4
+.equ	CAL5	= 5	; Oscillatro Calibration Value Bit 5
+.equ	CAL6	= 6	; Oscillatro Calibration Value Bit 6
+.equ	CAL7	= 7	; Oscillatro Calibration Value Bit 7
+
+; PLLCSR - PLL Control and status register
+.equ	PLOCK	= 0	; PLL Lock detector
+.equ	PLLE	= 1	; PLL Enable
+.equ	PCKE	= 2	; PCK Enable
+.equ	LSM	= 7	; Low speed mode
+
+; CLKPR - Clock Prescale Register
+.equ	CLKPS0	= 0	; Clock Prescaler Select Bit 0
+.equ	CLKPS1	= 1	; Clock Prescaler Select Bit 1
+.equ	CLKPS2	= 2	; Clock Prescaler Select Bit 2
+.equ	CLKPS3	= 3	; Clock Prescaler Select Bit 3
+.equ	CLKPCE	= 7	; Clock Prescaler Change Enable
+
+; DWDR - debugWire data register
+.equ	DWDR0	= 0	; 
+.equ	DWDR1	= 1	; 
+.equ	DWDR2	= 2	; 
+.equ	DWDR3	= 3	; 
+.equ	DWDR4	= 4	; 
+.equ	DWDR5	= 5	; 
+.equ	DWDR6	= 6	; 
+.equ	DWDR7	= 7	; 
+
+; GPIOR2 - General Purpose IO register 2
+.equ	GPIOR20	= 0	; 
+.equ	GPIOR21	= 1	; 
+.equ	GPIOR22	= 2	; 
+.equ	GPIOR23	= 3	; 
+.equ	GPIOR24	= 4	; 
+.equ	GPIOR25	= 5	; 
+.equ	GPIOR26	= 6	; 
+.equ	GPIOR27	= 7	; 
+
+; GPIOR1 - General Purpose register 1
+.equ	GPIOR10	= 0	; 
+.equ	GPIOR11	= 1	; 
+.equ	GPIOR12	= 2	; 
+.equ	GPIOR13	= 3	; 
+.equ	GPIOR14	= 4	; 
+.equ	GPIOR15	= 5	; 
+.equ	GPIOR16	= 6	; 
+.equ	GPIOR17	= 7	; 
+
+; GPIOR0 - General purpose register 0
+.equ	GPIOR00	= 0	; 
+.equ	GPIOR01	= 1	; 
+.equ	GPIOR02	= 2	; 
+.equ	GPIOR03	= 3	; 
+.equ	GPIOR04	= 4	; 
+.equ	GPIOR05	= 5	; 
+.equ	GPIOR06	= 6	; 
+.equ	GPIOR07	= 7	; 
+
+
+
+; ***** LOCKSBITS ********************************************************
+.equ	LB1	= 0	; Lockbit
+.equ	LB2	= 1	; Lockbit
+
+
+; ***** FUSES ************************************************************
+; LOW fuse bits
+.equ	CKSEL0	= 0	; Select Clock source
+.equ	CKSEL1	= 1	; Select Clock source
+.equ	CKSEL2	= 2	; Select Clock source
+.equ	CKSEL3	= 3	; Select Clock source
+.equ	SUT0	= 4	; Select start-up time
+.equ	SUT1	= 5	; Select start-up time
+.equ	CKOUT	= 6	; Clock Output Enable
+.equ	CKDIV8	= 7	; Divide clock by 8
+
+; HIGH fuse bits
+.equ	BODLEVEL0	= 0	; Brown-out Detector trigger level
+.equ	BODLEVEL1	= 1	; Brown-out Detector trigger level
+.equ	BODLEVEL2	= 2	; Brown-out Detector trigger level
+.equ	EESAVE	= 3	; EEPROM memory is preserved through the Chip Erase
+.equ	WDTON	= 4	; Watchdog Timer always on
+.equ	SPIEN	= 5	; Enable Serial Program and Data Downloading
+.equ	DWEN	= 6	; DebugWIRE Enable
+.equ	RSTDISBL	= 7	; External Reset disable
+
+; EXTENDED fuse bits
+.equ	SELFPRGEN	= 0	; Self-Programming Enable
+
+
+
+; ***** CPU REGISTER DEFINITIONS *****************************************
+.def	XH	= r27
+.def	XL	= r26
+.def	YH	= r29
+.def	YL	= r28
+.def	ZH	= r31
+.def	ZL	= r30
+
+
+
+; ***** DATA MEMORY DECLARATIONS *****************************************
+.equ	FLASHEND	= 0x0fff	; Note: Word address
+.equ	IOEND	= 0x003f
+.equ	SRAM_START	= 0x0060
+.equ	SRAM_SIZE	= 512
+.equ	RAMEND	= 0x025f
+.equ	XRAMEND	= 0x0000
+.equ	E2END	= 0x01ff
+.equ	EEPROMEND	= 0x01ff
+.equ	EEADRBITS	= 9
+#pragma AVRPART MEMORY PROG_FLASH 8192
+#pragma AVRPART MEMORY EEPROM 512
+#pragma AVRPART MEMORY INT_SRAM SIZE 512
+#pragma AVRPART MEMORY INT_SRAM START_ADDR 0x60
+
+
+
+; ***** BOOTLOADER DECLARATIONS ******************************************
+.equ	NRWW_START_ADDR	= 0x0
+.equ	NRWW_STOP_ADDR	= 0xfff
+.equ	RWW_START_ADDR	= 0x0
+.equ	RWW_STOP_ADDR	= 0x0
+.equ	PAGESIZE	= 32
+
+
+
+; ***** INTERRUPT VECTORS ************************************************
+.equ	INT0addr	= 0x0001	; External Interrupt 0
+.equ	PCIaddr	= 0x0002	; Pin Change Interrupt
+.equ	OC1Aaddr	= 0x0003	; Timer/Counter1 Compare Match 1A
+.equ	OC1Baddr	= 0x0004	; Timer/Counter1 Compare Match 1B
+.equ	OVF1addr	= 0x0005	; Timer/Counter1 Overflow
+.equ	OVF0addr	= 0x0006	; Timer/Counter0 Overflow
+.equ	USI_STARTaddr	= 0x0007	; USI Start
+.equ	USI_OVFaddr	= 0x0008	; USI Overflow
+.equ	ERDYaddr	= 0x0009	; EEPROM Ready
+.equ	ACIaddr	= 0x000a	; Analog Comparator
+.equ	ADCCaddr	= 0x000b	; ADC Conversion Complete
+.equ	WDTaddr	= 0x000c	; Watchdog Time-Out
+.equ	INT1addr	= 0x000d	; External Interrupt 1
+.equ	OC0Aaddr	= 0x000e	; Timer/Counter0 Compare Match A
+.equ	OC0Baddr	= 0x000f	; Timer/Counter0 Compare Match B
+.equ	ICP0addr	= 0x0010	; ADC Conversion Complete
+.equ	OC1Daddr	= 0x0011	; Timer/Counter1 Compare Match D
+.equ	FAULT_PROTaddr	= 0x0012	; Timer/Counter1 Fault Protection
+
+.equ	INT_VECTORS_SIZE	= 19	; size in words
+
+#endif  /* _TN861DEF_INC_ */
+
+; ***** END OF FILE ******************************************************

--- a/bootloader/version.asm
+++ b/bootloader/version.asm
@@ -1,0 +1,27 @@
+; Copyright 2023-2024 Stefan Jakobsson
+; 
+; Redistribution and use in source and binary forms, with or without modification, 
+; are permitted provided that the following conditions are met:
+;
+; 1. Redistributions of source code must retain the above copyright notice, this 
+;    list of conditions and the following disclaimer.
+;
+; 2. Redistributions in binary form must reproduce the above copyright notice, 
+;    this list of conditions and the following disclaimer in the documentation 
+;    and/or other materials provided with the distribution.
+;
+;    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
+;    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+;    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS 
+;    BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+;    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+;    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+;    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+;    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+;    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+;    THE POSSIBILITY OF SUCH DAMAGE.
+
+.cseg
+.org 0xfff
+.db $8a, 03


### PR DESCRIPTION
This adds the bootloader project as a subfolder.

The included code is for the new bootloader v3, which has improved security features compared to previous bootloader versions.

The bootloader has up til now been stored in my private Github repo: https://github.com/stefan-b-jakobsson/x16-smc-bootloader.

If included into the x16-smc I intend to close the private repo, and further development should be done in the x16-smc repo.