### PR TITLE
Fetch bootloader from X16Community repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           mv .doc/readme-community .build/community/readme
 
       - name: Fetch bootloader
-        run: wget -O .build/bootloader.hex https://github.com/stefan-b-jakobsson/x16-smc-bootloader/releases/download/2/bootloader.hex 
+        run: wget -O .build/bootloader.hex https://github.com/X16Community/x16-smc-bootloader/releases/download/v2/bootloader.hex
       
       - name: Create firmware_with_bootloader files
         run: |


### PR DESCRIPTION
Changes Github action to fetch bootloader binary from X16Community repo.