### PR TITLE
Add commands to read fuse settings, for SMC diagnostics (14 bytes), version 47.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ If you want to update the SMC firmware, please read this [guide](doc/update-guid
 | 0x07      | Master read       | 1 byte            | Get keyboard keycode          | 
 | 0x08      | Master write      | 1 byte            | Echo                          |
 | 0x09      | Master write      | 1 byte            | Debug output                  |
+| 0x0a      | Master read       | 1 byte            | Get low fuse setting          |
+| 0x0b      | Master read       | 1 byte            | Get lock bits                 |
+| 0x0c      | Master read       | 1 byte            | Get extended fuse setting     |
+| 0x0d      | Master read       | 1 byte            | Get high fuse setting         |
 | 0x18      | Master read       | 1 byte            | Get keyboard command status   |
 | 0x19      | Master write      | 1 byte            | Send keyboard command         |
 | 0x1a      | Master write      | 2 bytes           | Send keyboard command         | 
@@ -78,6 +82,18 @@ codes is available in the Kernal source.
 Key codes are one byte. Bit 7 indicates if the key was pressed (0) or released (1).
 
 This command gets one keycode from the buffer. If the buffer is empty, it returns 0.
+
+## Get fuses and lock bits (0x0a..0x0d)
+
+These offsets returns the fuse settings and lock bits (low-lock-extended-high).
+
+Expected value:
+- Low: $F1
+- Lock: $FF
+- Extended: $FE
+- High: $D4
+
+The reason for this particular order, is size optimization in SMC FW.
 
 ## Get keyboard command status (0x18)
 

--- a/version.h
+++ b/version.h
@@ -1,3 +1,3 @@
 #define version_major 47
 #define version_minor 2
-#define version_patch 3
+#define version_patch 4


### PR DESCRIPTION
New size: 7076 (max size 7680)

This PR adds the feature of reading fuse settings, to improve diagnostics options when SMC is not working.

To use this feature, add an AUTOBOOT.X16 to root of SD card which prints I2CPEEK at these addresses, and verify that they are what they should (F1 D4 FE). If they are something else (e.g. datasheet default 62 DF FF at 1 MHz), keyboard will not work, but, fuse settings can still be read.

There may be a few optimization options if code size should be kept at a minimum, but, there are still 604 bytes available.