### PR TITLE
Add host to device command timeout

### DIFF
--- a/ps2.h
+++ b/ps2.h
@@ -16,7 +16,6 @@ enum PS2_CMD_STATUS : uint8_t {
 enum PS2_CMD_TIMER : uint8_t {
   CMD_START = 255,
   CMD_DEVICE_READY = 253,
-  CMD_REWIND = 252,
   CMD_TIMEOUT = 1,
   CMD_INACTIVE = 0
 };
@@ -49,7 +48,7 @@ class PS2Port
     void resetReceiver() {
       resetInput();
       outputSize = 0;
-      timerCountdown = 0;
+      timerCountdown = PS2_CMD_TIMER::CMD_INACTIVE;
       flush();
     };
 
@@ -67,6 +66,7 @@ class PS2Port
       parity = 0;
       rxBitCount = 0;
       ps2ddr = 0;
+      timerCountdown = PS2_CMD_TIMER::CMD_INACTIVE;
     }
 
   public:
@@ -172,13 +172,13 @@ class PS2Port
        to the PS/2 device
     */
     void sendBit() {
-      if (timerCountdown >= 253) {
+      if (timerCountdown >= PS2_CMD_TIMER::CMD_DEVICE_READY) {
         //Ignore clock transitions during the request-to-send routine
         return;
       }
       else {
-        // Reset counter
-        timerCountdown = PS2_CMD_TIMER::CMD_REWIND;
+        // Rewind counter
+        timerCountdown = PS2_CMD_TIMER::CMD_DEVICE_READY - 1;
       }
 
       switch (rxBitCount)

--- a/ps2.h
+++ b/ps2.h
@@ -48,7 +48,6 @@ class PS2Port
     void resetReceiver() {
       resetInput();
       outputSize = 0;
-      timerCountdown = PS2_CMD_TIMER::CMD_INACTIVE;
       flush();
     };
 


### PR DESCRIPTION
This PR implements a timeout for host to device commands.

The PS/2 clock line is driven by the device. The SMC will currently wait forever until the device has clocked in the byte or bytes.