### PR TITLE
Include the SMCUPDATE tool

### DIFF
--- a/.doc/readme-community
+++ b/.doc/readme-community
@@ -3,41 +3,40 @@ IMPORTANT INFORMATION - PLEASE READ BEFORE INSTALLING
 
 1. Target board for this firmware
 
-    This firmware is made for the System Management
-    Controller of the CommunityX16 board designed
-    by Joe Burks (a.k.a. Wavicle).
+    This firmware is especially made for the 
+    CommunityX16 board designed by Joe Burks 
+    (a.k.a. Wavicle).
 
-    It is not recommended to use this firmware with
-    any other board. Doing so may break your system,
-    requiring the SMC to be programmed with an external
+    It is not recommended to use the firmware with
+    ANY other board. Doing so may break your system, 
+    requiring the SMC to be programmed with an external 
     programmer.
     
-    The firmware will not work with the official 
-    prototype 4 Commander X16 board that is sold through 
-    texelec.com.
+    This firmware will ABSOLUTELY not work with the 
+    official Commander X16 board that is sold through 
+    texelec.com, nor with Joe Burk's OtterX board.
 
+2.  The SMCUPDATE-x.x.x.PRG file
 
-2. The x16-smc.ino.hex file
+    This is an update program that runs on the
+    X16. The SMC firmware is embedded into the
+    file. Just run it and follow the on-screen
+    instructions.
 
-    This file contains the firmare in Intel HEX format.
-    
-    It can be used if you are programming the SMC with
-    an external programmer.
-
-    It can also be used if you program the SMC with
-    this tool:
-
-    https://github.com/stefan-b-jakobsson/x16-smc-update
-
+    This is the recommended tool for updating the 
+    SMC firmware.
 
 3.  The SMC-x.x.x.BIN file
 
-    This file contains the firmware in binary format plus
-    a header needed if you program the SMC with the
-    following tool:
+    This file contains the firmware in binary format. A header
+    is embedded in the file before the actual firmware,
+    needed if you program the SMC with this tool:
 
     https://github.com/FlightControl-User/x16-flash
 
+    Please note that the file can't be used to program
+    the SMC with an external programmer due to 
+    the header.
 
 4.  The firmware_with_bootloader.hex file
 
@@ -47,4 +46,16 @@ IMPORTANT INFORMATION - PLEASE READ BEFORE INSTALLING
 
     The bootloader source code is available here:
 
-    https://github.com/stefan-b-jakobsson/x16-smc-bootloader
+    https://github.com/X16Community/x16-smc-bootloader
+
+    This file can be used to program the SMC with
+    an external programmer.
+
+5. The x16-smc.ino.hex file
+
+    This file contains the firmare in Intel HEX format.
+    
+    This file can be used to program the SMC with
+    an external programmer.
+    
+    Please note that it does not contain a bootloader.

--- a/.doc/readme-default
+++ b/.doc/readme-default
@@ -4,36 +4,36 @@ IMPORTANT INFORMATION - PLEASE READ BEFORE INSTALLING
 1. Target board for this firmware
 
     This firmware is made for the System Management
-    Controller of the Commander X16 official prototype 4 
-    board that is sold through texelec.com.
+    Controller of the Commander X16 official board
+    that is sold through texelec.com and for Joe 
+    Burk's (a.k.a. Wavicle) OtterX board.
 
     It is not recommended to use this firmware with
     any other board. Doing so may break your system,
     requiring the SMC to be programmed with an external
     programmer.
 
+2.  The SMCUPDATE-x.x.x.PRG file
 
-2. The x16-smc.ino.hex file
+    This is an update program that runs on the
+    X16. The SMC firmware is embedded into the
+    file. Just run it and follow the on-screen
+    instructions.
 
-    This file contains the firmare in Intel HEX format.
-    
-    It can be used if you are programming the SMC with
-    an external programmer.
-
-    It can also be used if you program the SMC with
-    this tool:
-
-    https://github.com/stefan-b-jakobsson/x16-smc-update
-
+    This is the recommended tool for updating the 
+    SMC firmware.
 
 3.  The SMC-x.x.x.BIN file
 
-    This file contains the firmware in binary format plus
-    a header needed if you program the SMC with the
-    following tool:
+    This file contains the firmware in binary format. A header
+    is embedded in the file before the actual firmware,
+    needed if you program the SMC with this tool:
 
     https://github.com/FlightControl-User/x16-flash
 
+    Please note that the file can't be used to program
+    the SMC with an external programmer due to 
+    the header.
 
 4.  The firmware_with_bootloader.hex file
 
@@ -43,4 +43,17 @@ IMPORTANT INFORMATION - PLEASE READ BEFORE INSTALLING
 
     The bootloader source code is available here:
 
-    https://github.com/stefan-b-jakobsson/x16-smc-bootloader
+    https://github.com/X16Community/x16-smc-bootloader
+
+    This file can be used to program the SMC with
+    an external programmer.
+
+5. The x16-smc.ino.hex file
+
+    This file contains the firmare in Intel HEX format.
+    
+    This file can be used to program the SMC with
+    an external programmer.
+    
+    Please note that it does not contain a bootloader.
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: '3.9'
 
       - name: Create build folder
-        - run: make -p build
+        run: make -p build
       
       - name: Install IntelHex library
         run: pip install intelhex

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,59 +7,87 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Create build folder
+        - run: make -p build
+
       - uses: actions/checkout@v4
+      
       - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
+
+      - name: Install IntelHex library
+        run: pip install intelhex
+      
       - name: Setup Arduino CLI
         uses: arduino/setup-arduino-cli@v2
+      
       - name: Install ATTinyCore platform
         run: |
           arduino-cli core update-index --additional-urls file://$PWD/package_drazzy.com_index.json
           arduino-cli core install ATTinyCore:avr --additional-urls file://$PWD/package_drazzy.com_index.json
+      
       - name: Compile Arduino default sketch
-        run: arduino-cli compile -b ATTinyCore:avr:attinyx61 --board-options "chip=861,clock=16pll,pinmapping=new,TimerClockSource=default,LTO=enable,millis=enabled,eesave=aenable,bod=4v3" --build-path .build/default
+        run:  arduino-cli compile -b ATTinyCore:avr:attinyx61 --board-options "chip=861,clock=16pll,pinmapping=new,TimerClockSource=default,LTO=enable,millis=enabled,eesave=aenable,bod=4v3" --build-path build/default
+      
       - name: Compile Arduino sketch with Community X16 pin support
-        run: arduino-cli compile -b ATTinyCore:avr:attinyx61 --board-options "chip=861,clock=16pll,pinmapping=new,TimerClockSource=default,LTO=enable,millis=enabled,eesave=aenable,bod=4v3" --build-property "build.extra_flags=-DCOMMUNITYX16_PINS" --build-path .build/community
-      - name: Install IntelHex library
-        run: pip install intelhex
+        run: arduino-cli compile -b ATTinyCore:avr:attinyx61 --board-options "chip=861,clock=16pll,pinmapping=new,TimerClockSource=default,LTO=enable,millis=enabled,eesave=aenable,bod=4v3" --build-property "build.extra_flags=-DCOMMUNITYX16_PINS" --build-path build/community
+      
       - name: Make default SMC.BIN file
-        run: python make_bin.py ./.build/default/x16-smc.ino.hex .build/default
+        run: python make_bin.py ./build/default/x16-smc.ino.hex build/default
+      
       - name: Make SMC.BIN file with CommunityX16 pin support
-        run: python make_bin.py ./.build/community/x16-smc.ino.hex .build/community
+        run: python make_bin.py ./build/community/x16-smc.ino.hex build/community
+
+      - name: Build SMCUPDATE programs
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make build-essential
+          git clone https://github.com/cc65/cc65.git
+          cd cc65
+          make -j4
+          sudo make install
+          cd ..
+          cd update
+          make
+          cd ..
+          cp update/build/default/SMCUPDATE*.PRG build/default
+          cp update/build/community/SMCUPDATE*.PRG build/community
 
       - name: Move readme files to build folders
         run: |
-          mv .doc/readme-default .build/default/readme
-          mv .doc/readme-community .build/community/readme
+          mv .doc/readme-default build/default/readme
+          mv .doc/readme-community build/community/readme
 
       - name: Fetch bootloader
-        run: wget -O .build/bootloader.hex https://github.com/X16Community/x16-smc-bootloader/releases/download/v2/bootloader.hex
+        run: wget -O build/bootloader.hex https://github.com/X16Community/x16-smc-bootloader/releases/download/v2/bootloader.hex
       
       - name: Create firmware_with_bootloader files
         run: |
-          ./merge_bootloader.sh .build/default/x16-smc.ino.hex .build/bootloader.hex .build/default/firmware_with_bootloader.hex
-          ./merge_bootloader.sh .build/community/x16-smc.ino.hex .build/bootloader.hex .build/community/firmware_with_bootloader.hex
+          ./merge_bootloader.sh build/default/x16-smc.ino.hex build/bootloader.hex build/default/firmware_with_bootloader.hex
+          ./merge_bootloader.sh build/community/x16-smc.ino.hex build/bootloader.hex build/community/firmware_with_bootloader.hex
 
       - name: Archive default firmware
         uses: actions/upload-artifact@v4
         with:
           name: SMC default firmware
           path: |
-            .build/default/firmware_with_bootloader.hex
-            .build/default/x16-smc.ino.elf
-            .build/default/x16-smc.ino.hex
-            .build/default/SMC*.BIN
-            .build/default/readme
+            build/default/firmware_with_bootloader.hex
+            build/default/x16-smc.ino.elf
+            build/default/x16-smc.ino.hex
+            build/default/SMC*.BIN
+            build/default/SMCUPDATE*.PRG
+            build/default/readme
 
       - name: Archive CommunityX16 firmware
         uses: actions/upload-artifact@v4
         with:
           name: SMC CommunityX16 firmware
           path: |
-            .build/community/firmware_with_bootloader.hex
-            .build/community/x16-smc.ino.elf
-            .build/community/x16-smc.ino.hex
-            .build/community/SMC*.BIN
-            .build/community/readme
+            build/community/firmware_with_bootloader.hex
+            build/community/x16-smc.ino.elf
+            build/community/x16-smc.ino.hex
+            build/community/SMC*.BIN
+            build/community/SMCUPDATE*.PRG
+            build/community/readme
             

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: '3.9'
 
       - name: Create build folder
-        run: make -p build
+        run: mkdir -p build
       
       - name: Install IntelHex library
         run: pip install intelhex

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Create build folder
-        - run: make -p build
-
       - uses: actions/checkout@v4
       
       - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
+      - name: Create build folder
+        - run: make -p build
+      
       - name: Install IntelHex library
         run: pip install intelhex
       

--- a/update/Makefile
+++ b/update/Makefile
@@ -1,0 +1,15 @@
+BUILD_DIR=build
+RES_DIR=resources
+SRC_FILES=$(wildcard *.asm *.inc)
+PRGFILE=$(shell python scripts/prgname.py)
+
+$(BUILD_DIR)/$(PRGFILE): $(SRC_FILES)
+	@mkdir -p $(BUILD_DIR)
+	@mkdir -p $(RES_DIR)
+	python scripts/convert_hex2bin.py
+	cl65 -o $(BUILD_DIR)/$(PRGFILE) -u __EXEHDR__ -t cx16 -C cx16-asm.cfg main.asm
+	rm -f main.o
+
+# Clean
+clean:
+	rm -f $(BUILD_DIR)/*

--- a/update/Makefile
+++ b/update/Makefile
@@ -5,11 +5,15 @@ PRGFILE=$(shell python scripts/prgname.py)
 
 $(BUILD_DIR)/$(PRGFILE): $(SRC_FILES)
 	@mkdir -p $(BUILD_DIR)
+	@mkdir -p $(BUILD_DIR)/default
+	@mkdir -p $(BUILD_DIR)/community
 	@mkdir -p $(RES_DIR)
+	python scripts/version.py
 	python scripts/convert_hex2bin.py
-	cl65 -o $(BUILD_DIR)/$(PRGFILE) -u __EXEHDR__ -t cx16 -C cx16-asm.cfg main.asm
+	cl65 -o $(BUILD_DIR)/default/$(PRGFILE) -u __EXEHDR__ -t cx16 -C cx16-asm.cfg --asm-args -Dtarget_board=1 main.asm
+	cl65 -o $(BUILD_DIR)/community/$(PRGFILE) -u __EXEHDR__ -t cx16 -C cx16-asm.cfg --asm-args -Dtarget_board=2 main.asm
 	rm -f main.o
 
 # Clean
 clean:
-	rm -f $(BUILD_DIR)/*
+	rm -f -r $(BUILD_DIR)/*

--- a/update/README.md
+++ b/update/README.md
@@ -1,0 +1,71 @@
+# Introduction
+
+This is a client program running on the Commander X16 that updates the ATTiny861 based System Management Controller (SMC) firmware.
+
+The purpose of the program is to make it possible to update the SMC firmware without an external programmer. Firmware data is
+transmitted over I2C.
+
+
+# Prerequisites
+
+To run the SMC update program a bootloader must be installed on the SMC.
+
+
+# Normal usage
+
+The SMC update program is loaded and run in the same way as a BASIC program.
+
+When started the bootloader will first check that there is a bootloader installed in the SMC. The program will also
+check that it supports the installed bootloader version.
+
+The new firmware is embedded into the program file and you do not need any other files.
+
+The bootloader activation starts when the SMC update program sends a command over I2C to the SMC. To minimize the risk
+that a user sends this command by mistake, the user also needs to press the power and
+reset buttons on the computer. The buttons must be pressed at the same time or at least within 0.5 seconds of
+each other. The upload process is aborted if the buttons are not pressed within approx. 20 seconds.
+
+After the bootloader has been activated, the SMC update program transmits the new firmware to the SMC.
+
+The transmission is broken up into data packets of 8 bytes each. For each successful transmission a dot is printed to the screen.
+
+If the transmission fails, an error number is printed to the screen instead of a dot. The possible error numbers are:
+
+Err # | Description
+------| -----------
+2     | Data packet size error, indicating loss of a transmitted byte
+3     | Checksum error, indicating transmission error
+5     | Bootloader section overwrite, should not happen as it's checked before update starts
+
+In the event of an error, the SMC update program attempts to resend the same packet 10 times before aborting the
+update.
+
+When the update is done:
+
+- Bootloader v1: The bootloader enters into a loop waiting for the user to remove mains power
+- Bootloader v2: The bootloader resets the SMC which shuts down the system. You don't need to remove mains power, just press Power button to start the computer again.
+- Bootloader v2 (corrupted "bad" version): Some production boards comes with an unofficial corrupted v2 bootloader. The bootloader will not reset the system. Do not remove mains power, which will prevent the system from starting again. Instead you need to connect SMC pin #10 (reset) to ground with a jumper wire. This will turn off the system that can be started again with the Power button. A special warning is displayed in the update program if your board has the corrupted v2 bootloader.
+- Bootloader v3: The bootloader resets the SMC which shuts down the system. You don't need to remove mains power, just press Power button to start the computer again.
+
+# Unbricking the SMC
+
+If the update process fails it is likely that the computer is left in an inoperable state. You need to make a recovery update
+of the firmware for the computer to work again.
+
+## Recovery update with the SMCUPDATE program (available from bootloader v3)
+
+From bootloader v3 it is possible to do a recovery update without external tools using the SMCUPDATE program.
+
+Store SMCUPDATE.PRG as AUTOBOOT.X16 in the root folder of the SD card.
+
+Disconnect the computer from mains power at least until the LEDs are turned off.
+
+Press and hold the reset button at the same time as you connect the computer to mains power again. The computer should
+automatically turn on and run AUTOBOOT.X16. You may release the reset button as soon as you see that the power LED is on.
+
+The update program detects that the bootloader is active in recovery mode, and does the update without user interaction after a
+20 second countdown. If you want to abort the update you must disconnect the computer from mains power again.
+
+## Recovery with external tools
+
+Go to the x16-smc repo to learn about recovery with external programming tools.

--- a/update/license
+++ b/update/license
@@ -1,0 +1,23 @@
+Copyright 2023-2024 Stefan Jakobsson
+ 
+Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this 
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, 
+this list of conditions and the following disclaimer in the documentation 
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS 
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+THE POSSIBILITY OF SUCH DAMAGE.

--- a/update/main.asm
+++ b/update/main.asm
@@ -1,0 +1,578 @@
+; Supported bootloaders
+BOOTLOADER_MIN_VERSION = 1
+BOOTLOADER_MAX_VERSION = 3
+
+; Kernal functions
+KERNAL_CHROUT       = $ffd2
+I2C_READ            = $fec6
+I2C_WRITE           = $fec9
+I2C_ADDR            = $42
+
+KERNAL_SETNAM       = $ffbd
+KERNAL_OPEN         = $ffc0
+KERNAL_CLOSE        = $ffc3 
+KERNAL_SETLFS       = $ffba
+KERNAL_CHKIN        = $ffc6
+KERNAL_CLRCHN       = $ffcc
+KERNAL_READST       = $ffb7
+KERNAL_CHRIN        = $ffcf
+KERNAL_SCREEN_MODE  = $ff5f
+
+ROM_BANK            = $01
+tmp1                = $22
+
+.include "version.asm"
+
+.macro print str
+    ldx #<str
+    ldy #>str
+    jsr util_print_str
+.endmacro
+
+;******************************************************************************
+;Function name.......: main
+;Purpose.............: Program main entry
+;Input...............: Nothing
+;Returns.............: Nothing
+.proc main
+    ; Select ROM bank
+    lda ROM_BANK
+    pha
+    stz ROM_BANK
+
+    ; Get current firmware version
+    ldx #I2C_ADDR
+    ldy #$30
+    jsr I2C_READ
+    sta firmware_version
+
+    ldy #$31
+    jsr I2C_READ
+    sta firmware_version+1
+
+    ldy #$32
+    jsr I2C_READ
+    sta firmware_version+2
+
+    ; Check if bootloader already active and responds to I2C offset 0x83 (get bootloader version)
+    ldx #I2C_ADDR
+    ldy #$83        ; Get bootloader version
+    jsr I2C_READ
+    sta bootloader_version
+
+    cmp #255        ; Bootloader not active
+    bne :+
+    jsr manual_install
+    bra exit
+
+:   sta bootloader_version
+    jsr auto_install
+
+exit:
+    pla
+    sta ROM_BANK
+    rts
+
+.endproc
+
+
+;******************************************************************************
+;Function name.......: manual_install
+;Purpose.............: Manual install from the X16 with keyboard support
+;Input...............: Nothing
+;Returns.............: Nothing
+.proc manual_install
+    print str_appinfo
+    print str_automatic_fw_ver
+
+    ; Check bootloader version
+    ldx #I2C_ADDR
+    ldy #$8e
+    jsr I2C_READ
+    sta bootloader_version
+    cmp #$ff
+    bne :++
+
+    ; Try to get bootloader version from end of flash (>= bootloader v3)
+    ldx #I2C_ADDR
+    ldy #$90
+    lda #$7f
+    jsr I2C_WRITE
+
+    lda #62
+    sta temp
+    ldx #I2C_ADDR
+    ldy #$91
+ :  jsr I2C_READ
+    dec temp
+    bne :-
+
+    jsr I2C_READ
+    cmp #$8a
+    bne nobootloader
+    jsr I2C_READ
+    sta bootloader_version
+
+    ; Verify bootloader version support
+:   cmp #BOOTLOADER_MIN_VERSION
+    bcc unsupported_bootloader
+    cmp #BOOTLOADER_MAX_VERSION+1
+    bcs unsupported_bootloader
+    bra warning
+
+nobootloader:
+    print str_nobootloader
+    rts
+
+unsupported_bootloader:
+    pha
+    print str_unsupported_bootloader
+    pla
+    jsr util_print_num
+    rts
+
+warning:
+    ; Print standard warning
+    print str_warning
+
+    ; Print warning about v2 bootloader corruption on some production boards
+    lda bootloader_version
+    cmp #2
+    bne :+
+    print str_warning2
+
+:   print str_read_instructions
+
+    ; Confirm to continue
+:   print str_continue
+    jsr util_input
+    cpy #1
+    bne :-
+    lda util_input_buf
+    cmp #'y'
+    beq confirmed
+    cmp #'Y'
+    beq confirmed
+    cmp #'n'
+    beq exit
+    cmp #'N'
+    beq exit
+    bra :-
+    
+confirmed:
+    print str_activate_prompt
+    jsr util_input
+
+    jsr activate
+
+exit:
+    rts
+
+.endproc
+
+;******************************************************************************
+;Function name.......: auto_install
+;Purpose.............: Automatic install without keyboard support
+;Input...............: Nothing
+;Returns.............: Nothing
+.proc auto_install
+    print str_appinfo
+
+    lda bootloader_version
+    cmp #BOOTLOADER_MIN_VERSION
+    bcc unsupported_bootloader
+    cmp #BOOTLOADER_MAX_VERSION+1
+    bcc version_ok
+
+unsupported_bootloader:
+    print str_unsupported_bootloader
+    rts
+
+version_ok:
+    print str_automatic_fw_ver
+    print str_automatic_info
+    print str_warning
+    print str_automatic_countdown
+    ldx #60
+    jsr util_countdown
+    jmp update_firmware
+.endproc
+
+
+;******************************************************************************
+;Function name.......: activate
+;Purpose.............: Activates bootloader for manual update
+;Input...............: Nothing
+;Returns.............: Nothing
+.proc activate
+    ; Disable interrupts
+    sei
+
+    ; Send start bootloader command
+    ldx #I2C_ADDR
+    ldy #$8f
+    lda #$31
+    jsr I2C_WRITE
+
+    ; Prompt the user to activate bootloader within 20 seconds, and check if activated
+    print str_activate_countdown
+    ldx #20
+:   jsr util_stepdown
+    cpx #0
+    beq :+
+    
+    ldx #I2C_ADDR
+    ldy #$8e
+    jsr I2C_READ
+    cmp #0
+    beq :+
+    jsr util_delay
+    ldx #0
+    bra :-
+
+    ; Wait another 5 seconds to ensure bootloader is ready
+:   print str_activate_wait
+    ldx #5
+    jsr util_countdown
+
+    ; Check if bootloader activated
+    ldx #I2C_ADDR
+    ldy #$8e
+    jsr I2C_READ
+    cmp #0
+    beq :+
+    print str_bootloader_not_activated
+    cli
+    rts
+
+:   jmp update_firmware
+.endproc
+
+;******************************************************************************
+;Function name.......: update_firmware
+;Purpose.............: Updates the firmware
+;Input...............: Nothing
+;Returns.............: Nothing
+.proc update_firmware
+    ; Print upload begin alert
+    print str_upload
+
+    ; Setup pointer to start of buffer
+    lda #<payload
+    sta tmp1
+    lda #>payload
+    sta tmp1+1
+
+    ; Init variables
+    stz checksum
+    stz bytecount
+    lda #10
+    sta attempts
+
+loop:
+    ; Update checksum value
+    lda (tmp1)
+    clc
+    adc checksum
+    sta checksum
+    
+    ; Send packet byte
+    ldx #I2C_ADDR
+    ldy #$80
+    lda (tmp1)
+    jsr I2C_WRITE
+    
+    ; Update bytecount
+    inc bytecount
+    lda bytecount
+    and #$07            ; 8 bytes sent?
+    bne next_byte       ; No
+
+    ldx #I2C_ADDR       ; Yes, send checksum byte
+    ldy #$80
+    lda checksum
+    eor #$ff
+    ina
+    jsr I2C_WRITE
+
+    ldx #I2C_ADDR       ; Commit command
+    ldy #$81
+    jsr I2C_READ
+
+    cmp #1
+    beq ok
+    jsr util_print_num
+
+    dec attempts        ; Reached max attempts?
+    bne :+
+    jmp updatefailed
+
+:   sec                 ; Prepare to resend packet
+    lda tmp1
+    sbc #7
+    sta tmp1
+    lda tmp1+1
+    sbc #0
+    sta tmp1+1
+    stz checksum
+
+    bra loop
+
+ok:
+    lda #'.'            ; Print "." to indicate success
+    jsr KERNAL_CHROUT
+
+    ; Check if at end of page
+    lda bytecount
+    and #$3f
+    bne next_packet
+
+    ; Check if at end of firmware
+    lda tmp1+1
+    cmp #>payload_end
+    bcc next_packet
+    bne reboot
+
+    lda tmp1
+    cmp #<payload_end
+    bcs reboot
+
+next_packet:
+    stz checksum
+    lda #10
+    sta attempts
+
+next_byte:
+    inc tmp1            ; Increment buffer pointer
+    bne loop
+    inc tmp1+1
+    bra loop
+    
+reboot:
+    jsr verify_firmware
+
+    lda bootloader_version
+    cmp #2
+    bcs reboot2
+
+reboot1:
+    print str_done
+    ldx #I2C_ADDR
+    ldy #$82
+    jsr I2C_WRITE
+:   bra :-
+
+reboot2:
+    print str_done2
+    ldx #5
+    jsr util_countdown
+
+    ldx #I2C_ADDR
+    ldy #$82
+    jsr I2C_WRITE
+
+    ; Wait 2 seconds
+    jsr util_delay
+
+    ; Bad bootloader if we are still here
+    print str_bad_v2_bootloader
+:   bra :-
+
+updatefailed:
+    print str_updatefailed
+    
+    ; Try to reboot anyway
+    ldx #I2C_ADDR
+    ldy #$82
+    jsr I2C_WRITE
+
+    cli
+    rts
+    
+checksum: .res 1
+bytecount: .res 1
+attempts: .res 1
+.endproc
+
+;******************************************************************************
+;Function name.......: verify_firmware
+;Purpose.............: Compares firmware from SMC flash with new firmware
+;Input...............: Nothing
+;Returns.............: Nothing
+.proc verify_firmware
+    ; Check bootloader version >= 3
+    lda bootloader_version
+    cmp #3
+    bcs :+
+    rts
+
+:   ; Print message
+    print str_verifying
+
+    ; Setup variables
+    stz verified_count
+    stz verified_count+1
+    
+    stz fail_count
+    stz fail_count+1
+
+    stz fail_flag
+
+    sec
+    lda #<payload_end
+    sbc #<payload
+    sta firmware_size
+    lda #>payload_end
+    sbc #>payload
+    sta firmware_size+1
+
+    ; Setup vector to new firmware
+    lda #<payload
+    sta tmp1
+    lda #>payload
+    sta tmp1+1
+
+    ; Copy first page to temp buffer
+    ldy #0
+:   lda (tmp1),y
+    sta buffer,y
+    iny
+    cpy #64
+    bne :-
+
+    ; Move reset vector to EE_RDY in the temp buffer
+    sec
+    lda buffer+0
+    sbc #9
+    sta buffer+18
+    lda buffer+1
+    sbc #0
+    and #%11001111
+    ora #%11000000
+    sta buffer+19
+
+    ; Redirect reset vector to start of flash in the temp buffer
+    lda #$ff
+    sta buffer
+    lda #$ce
+    sta buffer+1
+
+    ; Rewind target address
+    ldx #I2C_ADDR
+    ldy #$84
+    lda #0
+    jsr I2C_WRITE
+
+    ; Read and compare first page
+    ldy #0
+compare1:
+    phy
+    ldx #I2C_ADDR
+    ldy #$85
+    jsr I2C_READ
+    ply
+    cmp buffer,y
+    bne :+
+    jsr compare_ok
+    bra next1
+:   jsr compare_fail
+
+next1:
+    jsr check_done
+    iny
+    cpy #64
+    bne compare1
+
+    ; Move pointer to second page
+    clc
+    lda tmp1
+    adc #64
+    sta tmp1
+    lda tmp1+1
+    adc #0
+    sta tmp1+1
+
+compare:
+    ldx #I2C_ADDR
+    ldy #$85
+    jsr I2C_READ
+    cmp (tmp1)
+    bne :+
+    jsr compare_ok
+    bra next
+:   jsr compare_fail
+
+next:
+    inc tmp1
+    bne :+
+    inc tmp1+1
+:   jsr check_done
+    bra compare
+
+compare_fail:
+    inc fail_count
+    bne :+
+    inc fail_count+1
+:   lda #1
+    sta fail_flag
+
+compare_ok:
+    inc verified_count
+    bne output
+    inc verified_count+1
+
+output:
+    lda verified_count
+    and #%00000111
+    beq :+
+    rts
+
+:   lda fail_flag
+    beq :+
+    lda #'F'
+    bra :++
+:   lda #'.'
+:   jsr KERNAL_CHROUT
+    stz fail_flag
+    rts
+
+check_done:
+    lda firmware_size
+    bne :+
+    dec firmware_size+1
+:   dec firmware_size
+
+    lda firmware_size
+    ora firmware_size+1
+    beq exit
+    rts
+
+exit:
+    pla
+    pla
+
+    lda fail_count
+    ora fail_count+1
+    bne err
+
+    print str_verify_ok
+    rts
+
+err:
+    print str_verify_fail
+    rts
+
+firmware_size: .res 2
+verified_count: .res 2
+fail_count: .res 2
+fail_flag: .res 1
+buffer: .res 64
+.endproc
+
+temp: .res 1
+firmware_version: .res 3
+bootloader_version: .res 1
+
+.include "util.asm"
+.include "str_en.asm"
+.include "payload.asm"

--- a/update/payload.asm
+++ b/update/payload.asm
@@ -1,0 +1,8 @@
+payload:
+    .incbin "resources/x16-smc.ino.bin"
+payload_end:
+
+payload_padding:
+    .repeat 64
+        .byte $ff
+    .endrepeat

--- a/update/payload.asm
+++ b/update/payload.asm
@@ -1,6 +1,19 @@
+.ifndef target_board
+    .error "target board not set"
+
+.elseif target_board=1
 payload:
-    .incbin "resources/x16-smc.ino.bin"
+    .incbin "resources/x16-smc-default.bin"
 payload_end:
+
+.elseif target_board=2
+payload:
+    .incbin "resources/x16-smc-community.bin"
+payload_end:
+
+.else
+    .error "unknown target board (1=default, 2=community)"
+.endif
 
 payload_padding:
     .repeat 64

--- a/update/scripts/convert_hex2bin.py
+++ b/update/scripts/convert_hex2bin.py
@@ -1,0 +1,5 @@
+from intelhex import IntelHex
+
+fw = IntelHex()
+fw.loadfile("resources/x16-smc.ino.hex", format="hex")
+fw.tofile("resources/x16-smc.ino.bin", format="bin")

--- a/update/scripts/convert_hex2bin.py
+++ b/update/scripts/convert_hex2bin.py
@@ -1,5 +1,9 @@
 from intelhex import IntelHex
 
-fw = IntelHex()
-fw.loadfile("resources/x16-smc.ino.hex", format="hex")
-fw.tofile("resources/x16-smc.ino.bin", format="bin")
+fw1 = IntelHex()
+fw1.loadfile("../build/default/x16-smc.ino.hex", format="hex")
+fw1.tofile("resources/x16-smc-default.bin", format="bin")
+
+fw2 = IntelHex()
+fw2.loadfile("../build/community/x16-smc.ino.hex", format="hex")
+fw2.tofile("resources/x16-smc-community.bin", format="bin")

--- a/update/scripts/prgname.py
+++ b/update/scripts/prgname.py
@@ -1,0 +1,16 @@
+f = open("version.asm")
+
+version = {}
+version["version_major"] = 0
+version["version_minor"] = 0
+version["version_patch"] = 0
+
+line = f.readline()
+while line:
+    parts = line.split()
+    if len(parts) >= 3 and parts[1] == "=":
+        version[parts[0].strip().lower()] = int(parts[2].strip())
+    line = f.readline()
+
+# Return SMCUPDATE file name with version
+print("SMCUPDATE-" + str(version["version_major"]) + "." + str(version["version_minor"]) + "." + str(version["version_patch"]) + ".PRG")

--- a/update/scripts/version.py
+++ b/update/scripts/version.py
@@ -12,5 +12,10 @@ while line:
         version[parts[1].strip().lower()] = int(parts[2].strip())
     line = f.readline()
 
-# Return SMCUPDATE file name with version
-print("SMCUPDATE-" + str(version["version_major"]) + "." + str(version["version_minor"]) + "." + str(version["version_patch"]) + ".PRG")
+f.close()
+
+f = open("version.asm", "w")
+f.write("version_major = " + str(version["version_major"]) + "\n")
+f.write("version_minor = " + str(version["version_minor"]) + "\n")
+f.write("version_patch = " + str(version["version_patch"]) + "\n")
+f.close()

--- a/update/str_en.asm
+++ b/update/str_en.asm
@@ -1,0 +1,92 @@
+COL_DEFAULT = $05
+COL_BG      = $1f
+COL_WARN    = $9e
+COL_OK      = $1e
+COL_ERR     = $96
+COL_SWAP    = $01 
+SCR_CLS     = 147
+SCR_PETSCII = $8f
+SCR_LOWER   = $0e
+
+str_appinfo:
+    .byt SCR_PETSCII, SCR_LOWER, COL_BG, COL_SWAP, COL_DEFAULT, SCR_CLS
+    .byt "COMMANDER X16 SYSTEM MANAGEMENT CONTROLLER UPDATE", 13, 13, 0
+
+str_nobootloader:
+    .byt COL_ERR, "ERROR:" , COL_DEFAULT, " SMC bootloader not installed or bootloader version could not be determined.", 0
+
+str_unsupported_bootloader:
+    .byt COL_ERR, "ERROR:", COL_DEFAULT, " Unsupported bootloader version: ", 0
+
+str_warning:
+    .byt COL_WARN, "WARNING: ", COL_DEFAULT
+    .byt "The computer may become inoperable if the update is interrupted "
+    .byt "or if it fails.", 13, 13, 0
+
+str_warning2:
+    .byt COL_WARN, "WARNING: ", COL_DEFAULT
+    .byt "Version 2 of the bootloader is installed on the SMC. "
+    .byt "That version is known to be corrupted on some production "
+    .byt "boards.", 13, 13, 0
+
+str_read_instructions:
+    .byt "Instructions at github.com/X16Community/x16-smc", 13, 0
+
+str_continue:
+    .byt 13, "Continue (Y/N): ", 0
+
+str_activate_prompt:
+    .byt 13, 13, "To start the update first press Enter and then within "
+    .byt "20 seconds momentarily press the Power and Reset buttons "
+    .byt "at the same time.", 13, 13
+    .byt "Press Enter: ", 0
+
+str_activate_countdown:
+    .byt 13, "Press Power and Reset buttons... ", 0
+
+str_activate_wait:
+    .byt 13, "Bootloader initializing... ", 0
+
+str_upload:
+    .byt 13, 13, "Writing to flash memory",13,0
+
+str_done:
+    .byt 13, COL_OK, "Update successful.", COL_DEFAULT, 13, 13
+    .byt "Disconnect mains power and wait 20 seconds before "
+    .byt "reconnecting power.", 0
+
+str_done2:
+    .byt 13, "System shutdown... ", 0
+
+str_bad_v2_bootloader:
+    .byt 13, 13, COL_WARN, "WARNING:", COL_DEFAULT, " Do NOT turn off the system.", 13, 13
+    .byt "The bootloader is corrupted, preventing the update from finishing. "
+    .byt "Complete the update by momentarily connecting SMC pin #10 (reset) "
+    .byt "to ground. Instructions available at "
+    .byt "github.com/X16Community/x16-smc.", 0
+
+str_updatefailed:
+    .byt 13, 13, COL_ERR, "Update failed.", COL_DEFAULT, 0
+
+str_bootloader_not_activated:
+    .byt 13, 13, COL_ERR, "Update aborted, bootloader not activated.", COL_DEFAULT, 0
+
+str_automatic_fw_ver:
+    .byt .sprintf("New firware version to be installed: %u.%u.%u.", version_major, version_minor, version_patch), 13, 13, 0
+
+str_automatic_info:
+    .byt "Instructions at github.com/X16Community/x16-smc.", 13, 13
+    .byt COL_WARN, "WARNING:", COL_DEFAULT, "The update continues automatically after the countdown. Disconnect the computer "
+    .byt "from mains power before the countdown ends if you want to abort.", 13, 13, 0
+
+str_automatic_countdown:
+    .byt "Update starts... ", 0
+
+str_verifying:
+    .byt 13, "Verifying flash memory", 13, 0
+
+str_verify_ok: 
+    .byt 13, "Verify OK", 13,0
+
+str_verify_fail: 
+    .byt 13, "Verfify failed",13, 0

--- a/update/util.asm
+++ b/update/util.asm
@@ -1,0 +1,290 @@
+;******************************************************************************
+; Function name.......: util_print_str
+; Purpose.............: Prints a null terminated string
+; Input...............: X = Pointer to string, address low
+;                       Y = Pointer to string, address high
+; Returns.............: Nothing
+.proc util_print_str
+    ; Store input
+    stx tmp1
+    sty tmp1+1
+    sta align
+
+    ; Get screen width
+    sec
+    jsr KERNAL_SCREEN_MODE
+    stx screen_width
+
+begin_line:
+    ldy #0
+    stz breakat
+    stz controlchars
+
+search:
+    lda (tmp1),y
+    beq setend
+    cmp #13
+    beq setend
+    cmp #32
+    bne :+
+
+    ; Remember index of last blank space
+    sty breakat
+
+:   ; Check if control char
+    lda (tmp1),y
+    cmp #COL_DEFAULT
+    beq :+
+    cmp #COL_BG
+    beq :+
+    cmp #COL_WARN
+    beq :+
+    cmp #COL_OK
+    beq :+
+    cmp #COL_ERR
+    beq :+
+    cmp #COL_SWAP
+    beq :+
+    cmp #SCR_CLS
+    beq :+
+    cmp #SCR_PETSCII
+    beq :+
+    cmp #SCR_LOWER
+    beq :+
+    bra :++
+
+:   inc controlchars
+
+    ; Check if at end of line
+:   iny
+    sec
+    tya
+    sbc controlchars
+    cmp screen_width
+    bcs output
+    bra search
+
+setend:
+    sty breakat
+
+output:
+    ldy #0
+:   lda (tmp1),y
+    beq exit
+    jsr KERNAL_CHROUT
+    cmp #13
+    beq advance
+    cpy breakat
+    beq breakhere
+    iny
+    bra :-
+
+breakhere:
+    sec
+    tya
+    ina
+    sbc controlchars
+    cmp screen_width
+    bcs advance
+    lda #13
+    jsr KERNAL_CHROUT
+
+advance:
+    clc
+    tya
+    ina
+    adc tmp1
+    sta tmp1
+    lda tmp1+1
+    adc #0
+    sta tmp1+1
+    jmp begin_line
+    
+exit:
+    rts
+
+breakat: .res 1
+controlchars: .res 1
+screen_width: .res 1
+align: .res 1
+.endproc
+
+;******************************************************************************
+; Function name.......: util_print_num
+; Purpose.............: Prints a byte value as decimal number
+; Input...............: A = byte value
+; Returns.............: Nothing
+.proc util_print_num
+    ; Store 8 bit input
+    sta input
+ 
+    ; Clear 16 bit output
+    stz output
+    stz output+1
+ 
+    ; Number of input bits
+    ldx #8
+ 
+    ; Set decimal mode
+    sed
+ 
+loop:
+    ; Rotate input, leftmost bit -> C
+    asl input
+   
+    ; 16 bit addition. Value of C from previous operation is the actual input. Therefore C is not cleared.
+    lda output
+    adc output
+    sta output
+   
+    lda output+1
+    adc output+1
+    sta output+1
+ 
+    ; Decrease bit counter, continue if > 0
+    dex
+    bne loop
+ 
+    ; Go back to binary mode
+    cld
+ 
+    ; Print
+    ldy #0
+
+    lda output+1                ; Third digit from right
+    and #15
+    beq :+
+    clc
+    adc #48
+    jsr KERNAL_CHROUT
+    iny
+
+:   lda output                  ; Second digit from right
+    lsr
+    lsr
+    lsr
+    lsr
+    cpy #0
+    bne :+
+    cmp #0
+    beq :++
+:   clc
+    adc #48
+    jsr KERNAL_CHROUT
+    iny
+
+:   lda output                  ; First digit from right
+    and #15
+    clc
+    adc #48
+    jmp KERNAL_CHROUT
+ 
+input: .res 1   
+output: .res 2
+.endproc
+
+;******************************************************************************
+; Function name.......: util_input
+; Purpose.............: Read string from keyboard
+; Input...............: Nothing
+; Returns.............: Y = string len
+;
+.proc util_input
+    ldy #0
+:   jsr KERNAL_CHRIN
+    cmp #13
+    beq exit
+    sta util_input_buf,y
+    iny
+    bra :-
+
+exit:
+    rts
+.endproc
+
+;******************************************************************************
+; Function name.......: util_stepdown
+; Purpose.............: 
+; Input...............: X = Start value, or 0 if no value
+; Returns.............: X = Current value
+.proc util_stepdown
+    ; Set start value if X != 0
+    cpx #0
+    beq delete
+    inx
+    stx value
+    bra printval
+
+delete:
+    ldx value
+
+    lda #20
+    jsr KERNAL_CHROUT
+    
+    cpx #10
+    bcc printval
+    lda #20
+    jsr KERNAL_CHROUT
+
+    cpx #100
+    bcc printval
+    lda #20
+    jsr KERNAL_CHROUT
+
+printval:
+    lda value
+    beq exit
+    dea
+    sta value
+    jsr util_print_num
+
+exit:
+    ldx value
+    rts
+
+value: .res 1
+.endproc
+
+;******************************************************************************
+; Function name.......: util_countdown
+; Purpose.............: 
+; Input...............: X = Countdown start value
+; Returns.............: Nothing
+.proc util_countdown
+    jsr util_stepdown
+    cpx #0
+    beq exit
+    jsr util_delay
+    ldx #0
+    bra util_countdown
+exit:
+    rts
+.endproc
+
+;******************************************************************************
+;Function name.......: util_delay
+;Purpose.............: Delay approx one second
+;Input...............: Nothing
+;Returns.............: Nothing
+.proc util_delay
+    lda #168
+    sta counter
+    lda #70
+    sta counter+1
+    lda #14
+    sta counter+2
+
+loop:
+    dec counter         ; 6
+    bne loop            ; 3     9x
+    dec counter+1       ; 6
+    bne loop            ; 3     9x / 256
+    dec counter+2       ; 6
+    bne loop            ; 3     9x / 65535
+    rts                 ; =>    9x + 9x/256 + 9x/65536 = 8000000 => 65536x + 256x + x = 8000000/9*65536 => x = 885416
+    
+    counter: .res 3
+.endproc
+
+
+util_input_buf: .res 256

--- a/update/version.asm
+++ b/update/version.asm
@@ -1,0 +1,3 @@
+version_major = 47
+version_minor = 2
+version_patch = 4

--- a/update/version.asm
+++ b/update/version.asm
@@ -1,3 +1,3 @@
 version_major = 47
 version_minor = 2
-version_patch = 4
+version_patch = 3


### PR DESCRIPTION
This PR includes the SMCUPDATE tool as a subfolder.

The firmware is embedded into the executable program which needs no other files to do an update.

Bootloader versions 1, 2 and 3 are supported by the tool.