### PR TITLE
Support bootloader version 3 in command offset 0x8E

### DIFF
--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -604,13 +604,13 @@ void I2C_Send() {
       break;
 
     case I2C_CMD_GET_BOOTLDR_VER:
-      if (pgm_read_byte(0x1ffe) == 0x8a) {
-        // From bootloader version 3
+      if (pgm_read_byte(0x1e00) == 0x8a) {
+        // Bootloader version 1 and 2
         smcWire.write(pgm_read_byte(0x1fff));
       }
-      else if (pgm_read_byte(0x1e00) == 0x8a) {
-        // Bootloader version 1 and 2
-        smcWire.write(pgm_read_byte(0x1e01));
+      else if (pgm_read_byte(0x1ffe) == 0x8a) {
+        // From bootloader version 3
+        smcWire.write(pgm_read_byte(0x1fff));
       }
       else {
         smcWire.write(0xff);

--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -605,7 +605,12 @@ void I2C_Send() {
 
     case I2C_CMD_GET_BOOTLDR_VER:
       if (pgm_read_byte(0x1e00) == 0x8a) {
+        // Bootloader version 1 and 2
         smcWire.write(pgm_read_byte(0x1e01));
+      }
+      else if (pgm_read_byte(01x0x1ffe) == 0x8a) {
+        // From bootloader version 3
+        smcWire.write(pgm_read_byte(0x1fff));
       }
       else {
         smcWire.write(0xff);

--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -604,13 +604,13 @@ void I2C_Send() {
       break;
 
     case I2C_CMD_GET_BOOTLDR_VER:
-      if (pgm_read_byte(0x1e00) == 0x8a) {
-        // Bootloader version 1 and 2
-        smcWire.write(pgm_read_byte(0x1e01));
-      }
-      else if (pgm_read_byte(0x1ffe) == 0x8a) {
+      if (pgm_read_byte(0x1ffe) == 0x8a) {
         // From bootloader version 3
         smcWire.write(pgm_read_byte(0x1fff));
+      }
+      else if (pgm_read_byte(0x1e00) == 0x8a) {
+        // Bootloader version 1 and 2
+        smcWire.write(pgm_read_byte(0x1e01));
       }
       else {
         smcWire.write(0xff);

--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -608,7 +608,7 @@ void I2C_Send() {
         // Bootloader version 1 and 2
         smcWire.write(pgm_read_byte(0x1e01));
       }
-      else if (pgm_read_byte(01x0x1ffe) == 0x8a) {
+      else if (pgm_read_byte(0x1ffe) == 0x8a) {
         // From bootloader version 3
         smcWire.write(pgm_read_byte(0x1fff));
       }

--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -606,7 +606,7 @@ void I2C_Send() {
     case I2C_CMD_GET_BOOTLDR_VER:
       if (pgm_read_byte(0x1e00) == 0x8a) {
         // Bootloader version 1 and 2
-        smcWire.write(pgm_read_byte(0x1fff));
+        smcWire.write(pgm_read_byte(0x1e01));
       }
       else if (pgm_read_byte(0x1ffe) == 0x8a) {
         // From bootloader version 3


### PR DESCRIPTION
Command offset 0x8E returns the bootloader version.

This adds support, so that the version is returned if you have bootloader 3 installed. Currently that doesn't work.