### PR TITLE
Add I2C offset to get the keyboard init state

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you want to update the SMC firmware, please read this [guide](doc/update-guid
 | 0x18      | Master read       | 1 byte            | Get keyboard command status   |
 | 0x19      | Master write      | 1 byte            | Send keyboard command         |
 | 0x1a      | Master write      | 2 bytes           | Send keyboard command         | 
-| 0x1b      | Master read       | 1 byte            | Get keyboard init state       | 
+| 0x1b      | Master read       | 1 byte            | Get keyboard ready state      | 
 | 0x20      | Master write      | 1 byte            | Set requested mouse device ID |
 | 0x21      | Master read       | 1, 3 or 4 bytes   | Get mouse movement            |
 | 0x22      | Master read       | 1 byte            | Get mouse device ID           |
@@ -119,17 +119,12 @@ I2CPOKE $42,$19,$f5
 
 Offset 0x1a sends a command that expects a command number and one data byte. This can't be done with the I2CPOKE command.
 
-## Get keyboard init state (0x1b)
+## Keyboard ready state (0x1b)
 
-Returns keyboard init state, which can be any of the following:
+Returns keyboard ready state.
 
-- 0x00 = keyboard off, or not connected
-- 0x01 = Basic Assurance Test (BAT) succeded
-- 0x02 = set LEDs command sent
-- 0x03 = set LEDs command ACKed
-- 0x04 = keyboard ready
-
-During normal operation, the keyboard init state is 0x04 (ready).
+The return value 0x01 indicates that the keyboard is ready. Any other value means that the keyboard is not yet initialized.
+The exact meaning of other return values than 0x01 is subject to change.
 
 ## Set requested mouse device ID (0x20)
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ If you want to update the SMC firmware, please read this [guide](doc/update-guid
 | 0x18      | Master read       | 1 byte            | Get keyboard command status   |
 | 0x19      | Master write      | 1 byte            | Send keyboard command         |
 | 0x1a      | Master write      | 2 bytes           | Send keyboard command         | 
+| 0x1b      | Master read       | 1 byte            | Get keyboard init state       | 
 | 0x20      | Master write      | 1 byte            | Set requested mouse device ID |
 | 0x21      | Master read       | 1, 3 or 4 bytes   | Get mouse movement            |
 | 0x22      | Master read       | 1 byte            | Get mouse device ID           |
@@ -117,6 +118,18 @@ I2CPOKE $42,$19,$f5
 ```
 
 Offset 0x1a sends a command that expects a command number and one data byte. This can't be done with the I2CPOKE command.
+
+## Get keyboard init state (0x1b)
+
+Returns keyboard init state, which can be any of the following:
+
+- 0x00 = keyboard off, or not connected
+- 0x01 = Basic Assurance Test (BAT) succeded
+- 0x02 = set LEDs command sent
+- 0x03 = set LEDs command ACKed
+- 0x04 = keyboard ready
+
+During normal operation, the keyboard init state is 0x04 (ready).
 
 ## Set requested mouse device ID (0x20)
 

--- a/ps2.h
+++ b/ps2.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <Arduino.h>
 #include "setup_ps2.h"
 #include "optimized_gpio.h"
@@ -466,7 +467,7 @@ class PS2KeyboardPort : public PS2Port<clkPin, datPin, size>
     */
     void processByteReceived(uint8_t value) {
       // Handle BAT success (0xaa) or fail (0xfc) code
-      if (!keyboardIsReady() && (value == 0xaa || value == 0xfc)) {
+      if (getKeyboardState() != KBD_STATE_READY && (value == 0xaa || value == 0xfc)) {
         bat = value;
         return;
       }

--- a/setup_keyboard.cpp
+++ b/setup_keyboard.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "ps2.h"
 #include "smc_pins.h"
 #include "setup_ps2.h"
@@ -7,13 +5,6 @@
 /*
     State Machine
 */
-
-// Setup
-#define KBD_STATE_OFF                   0x00
-#define KBD_STATE_BAT                   0x01
-#define KBD_STATE_SET_LEDS              0x02
-#define KBD_STATE_SET_LEDS_ACK          0x03
-#define KBD_STATE_READY                 0x04
 
 // Reset
 #define KBD_STATE_RESET                 0x10
@@ -124,6 +115,6 @@ void keyboardReset() {
   kbd_init_state = KBD_STATE_RESET;
 }
 
-bool keyboardIsReady() {
-  return kbd_init_state == KBD_STATE_READY;
+uint8_t getKeyboardState() {
+  return kbd_init_state;
 }

--- a/setup_keyboard.cpp
+++ b/setup_keyboard.cpp
@@ -3,14 +3,6 @@
 #include "setup_ps2.h"
 
 /*
-    State Machine
-*/
-
-// Reset
-#define KBD_STATE_RESET                 0x10
-#define KBD_STATE_RESET_ACK             0x11
-
-/*
     Watchdog
 */
 #define WATCHDOG_ARM                    255

--- a/setup_ps2.h
+++ b/setup_ps2.h
@@ -10,11 +10,12 @@ uint8_t getMousePacketSize();
 
 // Keyboard
 #define KBD_STATE_OFF                   0x00
-#define KBD_STATE_READY                 0x01    // This value exposed through I2C offset 0x1b, and should not be changed
-
+#define KBD_STATE_READY                 0x01
 #define KBD_STATE_BAT                   0x02
 #define KBD_STATE_SET_LEDS              0x03
 #define KBD_STATE_SET_LEDS_ACK          0x04
+#define KBD_STATE_RESET                 0x10
+#define KBD_STATE_RESET_ACK             0x11
 
 void keyboardTick();
 void keyboardReset();

--- a/setup_ps2.h
+++ b/setup_ps2.h
@@ -1,5 +1,6 @@
 #pragma once
 
+ // Mouse
 void mouseTick();
 void mouseReset();
 void mouseSetRequestedId(uint8_t);
@@ -7,6 +8,13 @@ uint8_t getMouseId();
 bool mouseIsReady();
 uint8_t getMousePacketSize();
 
+// Keyboard
+#define KBD_STATE_OFF                   0x00
+#define KBD_STATE_BAT                   0x01
+#define KBD_STATE_SET_LEDS              0x02
+#define KBD_STATE_SET_LEDS_ACK          0x03
+#define KBD_STATE_READY                 0x04
+
 void keyboardTick();
 void keyboardReset();
-bool keyboardIsReady();
+uint8_t getKeyboardState();

--- a/setup_ps2.h
+++ b/setup_ps2.h
@@ -10,10 +10,11 @@ uint8_t getMousePacketSize();
 
 // Keyboard
 #define KBD_STATE_OFF                   0x00
-#define KBD_STATE_BAT                   0x01
-#define KBD_STATE_SET_LEDS              0x02
-#define KBD_STATE_SET_LEDS_ACK          0x03
-#define KBD_STATE_READY                 0x04
+#define KBD_STATE_READY                 0x01    // This value exposed through I2C offset 0x1b, and should not be changed
+
+#define KBD_STATE_BAT                   0x02
+#define KBD_STATE_SET_LEDS              0x03
+#define KBD_STATE_SET_LEDS_ACK          0x04
 
 void keyboardTick();
 void keyboardReset();

--- a/version.h
+++ b/version.h
@@ -1,3 +1,3 @@
 #define version_major 47
 #define version_minor 2
-#define version_patch 4
+#define version_patch 5

--- a/x16-smc.ino
+++ b/x16-smc.ino
@@ -75,6 +75,7 @@
 #define I2C_CMD_GET_KBD_STATUS        0x18
 #define I2C_CMD_KBD_CMD1              0x19
 #define I2C_CMD_KBD_CMD2              0x1a
+#define I2C_CMD_KBD_INIT_STATE        0x1b
 #define I2C_CMD_SET_MOUSE_ID          0x20
 #define I2C_CMD_GET_MOUSE_MOV         0x21
 #define I2C_CMD_GET_MOUSE_ID          0x22
@@ -585,6 +586,10 @@ void I2C_Send() {
 
     case I2C_CMD_GET_KBD_STATUS:
       smcWire.write(Keyboard.getCommandStatus());
+      break;
+
+    case I2C_CMD_KBD_INIT_STATE:
+      smcWire.write(getKeyboardState());
       break;
 
     case I2C_CMD_GET_MOUSE_ID:


### PR DESCRIPTION
This PR makes it possible to get the state of the keyboard, that is if the keyboard has been initialized.

Example: PRINT I2CPEEK($42,$1B) returns 4 if the keyboard is ready.

The changes take 14 bytes.