### PR TITLE
Mouse ID fix when restarting the system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,11 +42,11 @@ jobs:
       - name: Build SMCUPDATE programs
         run: |
           sudo apt-get update
-          sudo apt-get install -y make build-essential
+          sudo apt-get install -y make build-essential libsdl2-dev
           git clone https://github.com/cc65/cc65.git
           cd cc65
-          make -j4
-          sudo make install
+          PREFIX=/usr/local make -j4
+          sudo bash -c 'PREFIX=/usr/local make install'
           cd ..
           cd update
           make

--- a/setup_mouse.cpp
+++ b/setup_mouse.cpp
@@ -104,6 +104,7 @@ void mouseTick() {
     if (!SYSTEM_POWERED && state != MOUSE_STATE_OFF) {
         Mouse.flush();
         state = MOUSE_STATE_OFF;
+        mouse_id = PS2_BAT_FAIL;
         watchdog = WATCHDOG_DISABLE;
         return;
     }

--- a/update/version.asm
+++ b/update/version.asm
@@ -1,3 +1,3 @@
-version_major = 47
-version_minor = 2
-version_patch = 3
+version_major = 48
+version_minor = 1
+version_patch = 0

--- a/version.h
+++ b/version.h
@@ -1,3 +1,3 @@
 #define version_major 48
-#define version_minor 0
+#define version_minor 1
 #define version_patch 0


### PR DESCRIPTION
The mouse ID is initially set to 0xFC (PS2_BAT_FAIL) when the SMC is reset.

The function mouse_tick(), that is called as part of the main loop, attempts to initialize the mouse and set the mouse ID accordingly as soon as the system is powered on by pushing the power button.

Currently, the mouse ID remains 0xFC if the initialization failed, for instance if there is no mouse present.

However, if a mouse is connected at first, and removed later on when the system is powered off but still connected to mains, the mouse ID is not changed when the system is powered on again. I2C offset 0x22 (Get Mouse Device ID) does not return the expected result 0xFC in this situation, and the Kernal will believe that there is still a mouse connected.

This fixes the issue described above by setting the mouse ID to PS2_BAT_FAIL when the system is powered off.